### PR TITLE
Fix archived pages view id

### DIFF
--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -70,7 +70,7 @@ const PageViews: FilterView[] = [
     ],
   },
   {
-    id: "drafts",
+    id: "archived",
     name: "Archived Pages",
     description: "Pages in archived status",
     conditions: [


### PR DESCRIPTION
## Summary
- ensure archived pages filter view uses a unique id

## Testing
- `pnpm lint` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b87ee23f083288749e5802109d884