### PR TITLE
feat(gallery-plugin): add gallery item management

### DIFF
--- a/packages/gallery-plugin/src/gallery/dto/gallery-item.dto.ts
+++ b/packages/gallery-plugin/src/gallery/dto/gallery-item.dto.ts
@@ -1,0 +1,37 @@
+import { ApiProperty, ApiPropertyOptional } from "@nestjs/swagger";
+import { IsIn, IsMongoId, IsOptional, IsString } from "class-validator";
+import { GalleryItemModel } from "../models/gallery-item.model";
+
+export class GalleryItemDto implements GalleryItemModel {
+  @ApiProperty({ description: "Asset ID", example: "60f7c0a2d3a8f009e6f0b7d1" })
+  @IsMongoId()
+  assetId: string;
+
+  @ApiPropertyOptional({ description: "Order of the item", example: 0 })
+  @IsOptional()
+  order?: number;
+
+  @ApiPropertyOptional({ description: "Caption for the item" })
+  @IsOptional()
+  @IsString()
+  caption?: string;
+
+  @ApiPropertyOptional({ description: "Alternate text override" })
+  @IsOptional()
+  @IsString()
+  altOverride?: string;
+
+  @ApiPropertyOptional({ description: "Link URL" })
+  @IsOptional()
+  @IsString()
+  linkUrl?: string;
+
+  @ApiPropertyOptional({ enum: ["visible", "hidden"], default: "visible" })
+  @IsOptional()
+  @IsIn(["visible", "hidden"])
+  visibility?: "visible" | "hidden";
+
+  constructor(partial: Partial<GalleryItemDto>) {
+    Object.assign(this, partial);
+  }
+}

--- a/packages/gallery-plugin/src/gallery/dto/gallery-seo.dto.ts
+++ b/packages/gallery-plugin/src/gallery/dto/gallery-seo.dto.ts
@@ -1,0 +1,30 @@
+import { ApiPropertyOptional } from "@nestjs/swagger";
+import { IsArray, IsOptional, IsString } from "class-validator";
+import { GallerySeoModel } from "../models/gallery-seo.model";
+
+export class GallerySeoDto implements GallerySeoModel {
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  metaTitle: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  metaDescription: string;
+
+  @ApiPropertyOptional({ type: [String] })
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  metaKeywords?: string[];
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  canonical?: string;
+
+  constructor(partial: Partial<GallerySeoDto>) {
+    Object.assign(this, partial);
+  }
+}

--- a/packages/gallery-plugin/src/gallery/dto/gallery-sort.dto.ts
+++ b/packages/gallery-plugin/src/gallery/dto/gallery-sort.dto.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { IsArray, IsString } from "class-validator";
+
+export class GallerySortDto {
+  @ApiProperty({ type: [String], description: "Ordered list of item IDs" })
+  @IsArray()
+  @IsString({ each: true })
+  itemIds: string[];
+}

--- a/packages/gallery-plugin/src/gallery/dto/gallery-upsert.dto.ts
+++ b/packages/gallery-plugin/src/gallery/dto/gallery-upsert.dto.ts
@@ -4,7 +4,6 @@ import {
   IsArray,
   IsDateString,
   IsEnum,
-  IsIn,
   IsMongoId,
   IsNotEmpty,
   IsOptional,
@@ -12,69 +11,8 @@ import {
   ValidateNested,
 } from "class-validator";
 import { GalleryStatus } from "../models/gallery-status.enum";
-import { GallerySeoModel } from "../models/gallery-seo.model";
-import { GalleryItemModel } from "../models/gallery-item.model";
-
-export class GalleryItemDto implements GalleryItemModel {
-  @ApiProperty({ description: "Asset ID", example: "60f7c0a2d3a8f009e6f0b7d1" })
-  @IsMongoId()
-  assetId: string;
-
-  @ApiPropertyOptional({ description: "Order of the item", example: 0 })
-  @IsOptional()
-  order?: number;
-
-  @ApiPropertyOptional({ description: "Caption for the item" })
-  @IsOptional()
-  @IsString()
-  caption?: string;
-
-  @ApiPropertyOptional({ description: "Alternate text override" })
-  @IsOptional()
-  @IsString()
-  altOverride?: string;
-
-  @ApiPropertyOptional({ description: "Link URL" })
-  @IsOptional()
-  @IsString()
-  linkUrl?: string;
-
-  @ApiPropertyOptional({ enum: ["visible", "hidden"], default: "visible" })
-  @IsOptional()
-  @IsIn(["visible", "hidden"])
-  visibility?: "visible" | "hidden";
-
-  constructor(partial: Partial<GalleryItemDto>) {
-    Object.assign(this, partial);
-  }
-}
-
-export class GallerySeoDto implements GallerySeoModel {
-  @ApiPropertyOptional()
-  @IsOptional()
-  @IsString()
-  metaTitle: string;
-
-  @ApiPropertyOptional()
-  @IsOptional()
-  @IsString()
-  metaDescription: string;
-
-  @ApiPropertyOptional({ type: [String] })
-  @IsOptional()
-  @IsArray()
-  @IsString({ each: true })
-  metaKeywords?: string[];
-
-  @ApiPropertyOptional()
-  @IsOptional()
-  @IsString()
-  canonical?: string;
-
-  constructor(partial: Partial<GallerySeoDto>) {
-    Object.assign(this, partial);
-  }
-}
+import { GalleryItemDto } from "./gallery-item.dto";
+import { GallerySeoDto } from "./gallery-seo.dto";
 
 export class GalleryUpsertDto {
   @ApiPropertyOptional()
@@ -146,4 +84,3 @@ export class GalleryUpsertDto {
     Object.assign(this, partial);
   }
 }
-

--- a/packages/gallery-plugin/src/gallery/gallery.controller.ts
+++ b/packages/gallery-plugin/src/gallery/gallery.controller.ts
@@ -20,6 +20,8 @@ import type { JwtPayloadModel } from "@kitejs-cms/core";
 import { GalleryService } from "./services/gallery.service";
 import { GalleryResponseDto } from "./dto/gallery-response.dto";
 import { GalleryUpsertDto } from "./dto/gallery-upsert.dto";
+import { GalleryItemDto } from "./dto/gallery-item.dto";
+import { GallerySortDto } from "./dto/gallery-sort.dto";
 
 @ApiTags("Gallery")
 @Controller("galleries")
@@ -53,19 +55,58 @@ export class GalleryController {
     return new GalleryResponseDto(gallery);
   }
 
-  @Get(":id")
-  @UseGuards(JwtAuthGuard)
-  @ApiBearerAuth()
-  @ApiOperation({ summary: "Get gallery by id" })
-  async getGallery(@Param("id") id: string) {
-    const gallery = await this.galleryService.findGalleryById(id);
-    return new GalleryResponseDto(gallery);
-  }
+    @Get(":id")
+    @UseGuards(JwtAuthGuard)
+    @ApiBearerAuth()
+    @ApiOperation({ summary: "Get gallery by id" })
+    async getGallery(@Param("id") id: string) {
+      const gallery = await this.galleryService.findGalleryById(id);
+      return new GalleryResponseDto(gallery);
+    }
 
-  @Delete(":id")
-  @UseGuards(JwtAuthGuard)
-  @ApiBearerAuth()
-  @HttpCode(200)
+    @Post(":id/items")
+    @UseGuards(JwtAuthGuard)
+    @ApiBearerAuth()
+    @ApiOperation({ summary: "Add item to gallery" })
+    async addItem(
+      @Param("id", ValidateObjectIdPipe) id: string,
+      @Body() dto: GalleryItemDto,
+      @GetAuthUser() user: JwtPayloadModel
+    ) {
+      const gallery = await this.galleryService.addItem(id, dto, user);
+      return new GalleryResponseDto(gallery);
+    }
+
+    @Delete(":id/items/:itemId")
+    @UseGuards(JwtAuthGuard)
+    @ApiBearerAuth()
+    @ApiOperation({ summary: "Remove item from gallery" })
+    async removeItem(
+      @Param("id", ValidateObjectIdPipe) id: string,
+      @Param("itemId", ValidateObjectIdPipe) itemId: string,
+      @GetAuthUser() user: JwtPayloadModel
+    ) {
+      const gallery = await this.galleryService.removeItem(id, itemId, user);
+      return new GalleryResponseDto(gallery);
+    }
+
+    @Post(":id/items/sort")
+    @UseGuards(JwtAuthGuard)
+    @ApiBearerAuth()
+    @ApiOperation({ summary: "Sort gallery items" })
+    async sortItems(
+      @Param("id", ValidateObjectIdPipe) id: string,
+      @Body() dto: GallerySortDto,
+      @GetAuthUser() user: JwtPayloadModel
+    ) {
+      const gallery = await this.galleryService.sortItems(id, dto.itemIds, user);
+      return new GalleryResponseDto(gallery);
+    }
+
+    @Delete(":id")
+    @UseGuards(JwtAuthGuard)
+    @ApiBearerAuth()
+    @HttpCode(200)
   @ApiOperation({ summary: "Delete gallery" })
   async deleteGallery(@Param("id", ValidateObjectIdPipe) id: string) {
     const result = await this.galleryService.deleteGallery(id);

--- a/packages/gallery-plugin/src/gallery/index.ts
+++ b/packages/gallery-plugin/src/gallery/index.ts
@@ -7,7 +7,10 @@ export * from "./models/gallery-upsert.model";
 export * from "./models/gallery-response.model";
 
 /* Dto */
+export * from "./dto/gallery-item.dto";
+export * from "./dto/gallery-seo.dto";
 export * from "./dto/gallery-upsert.dto";
+export * from "./dto/gallery-sort.dto";
 export * from "./dto/gallery-response.dto";
 
 /* Services */

--- a/packages/gallery-plugin/src/gallery/services/gallery.service.ts
+++ b/packages/gallery-plugin/src/gallery/services/gallery.service.ts
@@ -7,6 +7,7 @@ import { InjectModel } from "@nestjs/mongoose";
 import { Model, Types } from "mongoose";
 import { Gallery } from "../schemas/gallery.schema";
 import { GalleryUpsertDto } from "../dto/gallery-upsert.dto";
+import { GalleryItemDto } from "../dto/gallery-item.dto";
 import { SlugRegistryService } from "@kitejs-cms/core";
 import type { JwtPayloadModel } from "@kitejs-cms/core";
 import { GALLERY_SLUG_NAMESPACE } from "../../constants";
@@ -136,6 +137,84 @@ export class GalleryService {
       const message = error instanceof Error ? error.message : String(error);
       throw new BadRequestException(`Failed to delete gallery. ${message}`);
     }
+  }
+
+  async addItem(
+    galleryId: string,
+    item: GalleryItemDto,
+    user: JwtPayloadModel
+  ): Promise<GalleryResponseModel> {
+    const gallery = await this.galleryModel.findByIdAndUpdate(
+      galleryId,
+      { $push: { items: item }, updatedBy: user.sub },
+      { new: true }
+    );
+
+    if (!gallery) {
+      throw new NotFoundException(`Gallery with ID ${galleryId} not found`);
+    }
+
+    return this.findGalleryById(galleryId);
+  }
+
+  async removeItem(
+    galleryId: string,
+    itemId: string,
+    user: JwtPayloadModel
+  ): Promise<GalleryResponseModel> {
+    const gallery = await this.galleryModel.findByIdAndUpdate(
+      galleryId,
+      { $pull: { items: { _id: itemId } }, updatedBy: user.sub },
+      { new: true }
+    );
+
+    if (!gallery) {
+      throw new NotFoundException(
+        `Gallery with ID ${galleryId} or item ${itemId} not found`
+      );
+    }
+
+    return this.findGalleryById(galleryId);
+  }
+
+  async sortItems(
+    galleryId: string,
+    itemIds: string[],
+    user: JwtPayloadModel
+  ): Promise<GalleryResponseModel> {
+    const gallery = await this.galleryModel.findById(galleryId).exec();
+    if (!gallery) {
+      throw new NotFoundException(`Gallery with ID ${galleryId} not found`);
+    }
+
+    const itemsMap = new Map(
+      gallery.items.map((item: any) => [item._id.toString(), item])
+    );
+
+    const reordered: typeof gallery.items = [];
+    for (let index = 0; index < itemIds.length; index++) {
+      const id = itemIds[index];
+      const item = itemsMap.get(id);
+      if (!item) {
+        throw new BadRequestException(
+          `Item with ID ${id} not found in gallery`
+        );
+      }
+      item.order = index;
+      reordered.push(item);
+      itemsMap.delete(id);
+    }
+
+    for (const item of itemsMap.values()) {
+      item.order = reordered.length;
+      reordered.push(item);
+    }
+
+    gallery.items = reordered as any;
+    (gallery as any).updatedBy = user.sub;
+    await gallery.save();
+
+    return this.findGalleryById(galleryId);
   }
 }
 


### PR DESCRIPTION
## Summary
- split gallery DTOs into dedicated files
- add endpoints and service methods to add, remove and sort gallery items

## Testing
- `pnpm --filter @kitejs-cms/gallery-plugin lint` (fails: The requested module '@kitejs-cms/eslint-config/nest' does not provide an export named 'default')
- `pnpm --filter @kitejs-cms/gallery-plugin build` (fails: Cannot find module '@kitejs-cms/core')

------
https://chatgpt.com/codex/tasks/task_e_689fa08ef7208328b4e893a934714681