### PR TITLE
feat(gallery): create standalone package

### DIFF
--- a/packages/dashboard-core/package.json
+++ b/packages/dashboard-core/package.json
@@ -51,6 +51,7 @@
     "typescript": "5.7.3"
   },
   "dependencies": {
+    "@kitejs-cms/dashboard-gallery": "workspace:*",
     "@aws-sdk/s3-request-presigner": "^3.787.0",
     "@blocknote/core": "^0.33.0",
     "@blocknote/mantine": "^0.33.0",

--- a/packages/dashboard-core/src/dashboard-provider.tsx
+++ b/packages/dashboard-core/src/dashboard-provider.tsx
@@ -12,6 +12,7 @@ import { ProfileModule } from "./modules/profile";
 import { CoreModule } from "./modules/core";
 import { PageModule } from "./modules/pages";
 import { PostModule } from "./modules/articles";
+import { GalleryModule } from "@kitejs-cms/dashboard-gallery";
 import { DashboardPage } from "./modules/core/pages/dashboard";
 
 interface DashboardRouterProps {
@@ -24,11 +25,12 @@ export function DashboardProvider({ modules = [] }: DashboardRouterProps) {
     ProfileModule,
     PageModule,
     PostModule,
+    GalleryModule,
   ];
   const allModules = [...coreModules, ...modules];
 
   const modulesWithTranslations = [CoreModule, ...allModules].filter(
-    (mod) => mod.translations
+    (mod) => mod.translations,
   );
   modulesWithTranslations.forEach((mod) => {
     Object.entries(mod.translations!).forEach(([lang, translations]) => {
@@ -53,7 +55,7 @@ export function DashboardProvider({ modules = [] }: DashboardRouterProps) {
         path={route.path}
         element={route.element}
       />
-    ))
+    )),
   );
 
   return (

--- a/packages/dashboard-gallery/eslint.config.mjs
+++ b/packages/dashboard-gallery/eslint.config.mjs
@@ -1,0 +1,4 @@
+import { config } from "@kitejs-cms/eslint-config/react-internal";
+
+/** @type {import("eslint").Linter.Config} */
+export default config;

--- a/packages/dashboard-gallery/package.json
+++ b/packages/dashboard-gallery/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "@kitejs-cms/dashboard-gallery",
+  "version": "0.1.0-alpha.0",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": ["dist"],
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "./*": {
+      "import": "./dist/*.js",
+      "require": "./dist/*.js",
+      "types": "./dist/*.d.ts"
+    }
+  },
+  "scripts": {
+    "build": "tsc --build tsconfig.json",
+    "dev": "tsc --build tsconfig.json --watch",
+    "check-types": "tsc --noEmit",
+    "lint": "eslint src --ext .ts,.tsx --max-warnings 0"
+  },
+  "peerDependencies": {
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  },
+  "dependencies": {
+    "@kitejs-cms/dashboard-core": "workspace:*"
+  },
+  "devDependencies": {
+    "@kitejs-cms/eslint-config": "workspace:*",
+    "@kitejs-cms/typescript-config": "workspace:*",
+    "@types/node": "^22.13.0",
+    "@types/react": "19.0.8",
+    "@types/react-dom": "19.0.3",
+    "eslint": "^9.20.0",
+    "typescript": "5.7.3"
+  }
+}

--- a/packages/dashboard-gallery/src/components/gallery-settings.tsx
+++ b/packages/dashboard-gallery/src/components/gallery-settings.tsx
@@ -1,0 +1,69 @@
+import type { FieldDefinition } from "@kitejs-cms/core/index";
+import { CustomFieldBuilder } from "@kitejs-cms/dashboard-core/components/custom-field-builder";
+import { useEffect, useState } from "react";
+import { Button } from "@kitejs-cms/dashboard-core/components/ui/button";
+import { useTranslation } from "react-i18next";
+import { useSettingsContext } from "@kitejs-cms/dashboard-core/context/settings-context";
+
+export function GallerySettings() {
+  const [galleryFields, setGalleryFields] = useState<FieldDefinition[]>([]);
+  const { getSetting, updateSetting, setHasUnsavedChanges, hasUnsavedChanges } =
+    useSettingsContext();
+  const { t } = useTranslation("core");
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    const loadFields = async () => {
+      try {
+        const { value } = await getSetting<{
+          value: { customFields: FieldDefinition[] };
+        }>("core", "core:gallery");
+
+        if (value?.customFields) {
+          setGalleryFields(value.customFields);
+        }
+      } catch (error) {
+        console.error("Failed to load gallery fields:", error);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    loadFields();
+  }, [getSetting]);
+
+  const handleFieldsChange = (newFields: FieldDefinition[]) => {
+    setGalleryFields(newFields);
+    setHasUnsavedChanges(true);
+  };
+
+  const handleSave = async () => {
+    try {
+      setIsLoading(true);
+      await updateSetting("core", "core:gallery", {
+        customFields: galleryFields,
+      });
+      setHasUnsavedChanges(false);
+    } catch (error) {
+      console.error("Failed to save gallery fields:", error);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  if (isLoading) {
+    return <div>{t("common.loading", "Loading...")}</div>;
+  }
+
+  return (
+    <div className="pb-16">
+      <CustomFieldBuilder value={galleryFields} onChange={handleFieldsChange} />
+
+      <div className="fixed bottom-4 right-4 p-4">
+        <Button onClick={handleSave} disabled={!hasUnsavedChanges || isLoading}>
+          {t("common.save", "Save")}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/packages/dashboard-gallery/src/index.tsx
+++ b/packages/dashboard-gallery/src/index.tsx
@@ -1,0 +1,45 @@
+import { Images } from "lucide-react";
+import type { DashboardModule } from "@kitejs-cms/dashboard-core/models/module.model";
+import { GalleriesManagePage } from "./pages/galleries-manage";
+import { GalleryDetailsPage } from "./pages/gallery-details";
+import { GallerySettings } from "./components/gallery-settings";
+
+import it from "./locales/it.json";
+import en from "./locales/en.json";
+
+export const GalleryModule: DashboardModule = {
+  name: "galleries",
+  key: "galleries",
+  translations: { it, en },
+  settings: {
+    key: "galleries",
+    title: "galleries:menu.galleries",
+    icon: <Images />,
+    description: "galleries:settings.description",
+    children: [
+      {
+        key: "gallery-fields",
+        title: "galleries:settings.fields.title",
+        icon: <Images />,
+        component: <GallerySettings />,
+      },
+    ],
+  },
+  routes: [
+    {
+      path: "galleries",
+      element: <GalleriesManagePage />,
+      label: "galleries:menu.galleries",
+    },
+    {
+      path: "galleries/:id",
+      element: <GalleryDetailsPage />,
+      label: "galleries:menu.galleries",
+    },
+  ],
+  menuItem: {
+    title: "galleries:menu.galleries",
+    icon: Images,
+    url: "/galleries",
+  },
+};

--- a/packages/dashboard-gallery/src/locales/en.json
+++ b/packages/dashboard-gallery/src/locales/en.json
@@ -1,0 +1,11 @@
+{
+  "menu": {
+    "galleries": "Galleries"
+  },
+  "settings": {
+    "description": "Configure gallery settings",
+    "fields": {
+      "title": "Gallery Fields"
+    }
+  }
+}

--- a/packages/dashboard-gallery/src/locales/it.json
+++ b/packages/dashboard-gallery/src/locales/it.json
@@ -1,0 +1,11 @@
+{
+  "menu": {
+    "galleries": "Gallerie"
+  },
+  "settings": {
+    "description": "Configura le impostazioni della galleria",
+    "fields": {
+      "title": "Campi galleria"
+    }
+  }
+}

--- a/packages/dashboard-gallery/src/pages/galleries-manage.tsx
+++ b/packages/dashboard-gallery/src/pages/galleries-manage.tsx
@@ -1,0 +1,5 @@
+import { SkeletonPage } from "@kitejs-cms/dashboard-core/components/skeleton-page";
+
+export function GalleriesManagePage() {
+  return <SkeletonPage />;
+}

--- a/packages/dashboard-gallery/src/pages/gallery-details.tsx
+++ b/packages/dashboard-gallery/src/pages/gallery-details.tsx
@@ -1,0 +1,5 @@
+import { SkeletonPage } from "@kitejs-cms/dashboard-core/components/skeleton-page";
+
+export function GalleryDetailsPage() {
+  return <SkeletonPage />;
+}

--- a/packages/dashboard-gallery/tsconfig.json
+++ b/packages/dashboard-gallery/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "@kitejs-cms/typescript-config/react-library.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "noImplicitAny": false,
+    "strictNullChecks": false,
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": false,
+    "strictPropertyInitialization": false,
+    "isolatedModules": false,
+    "skipLibCheck": true,
+    "module": "ES2022",
+    "esModuleInterop": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary
- extract gallery module into dedicated `@kitejs-cms/dashboard-gallery` package with routes, settings and translations
- consume gallery package from dashboard provider