### PR TITLE
feat: add gallery dashboard module

### DIFF
--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@kitejs-cms/dashboard-core": "workspace:*",
+    "@kitejs-cms/gallery-dashboard": "workspace:*",
     "@tailwindcss/vite": "^4.0.8",
     "install": "^0.13.0",
     "react": "^19.0.0",

--- a/apps/dashboard/src/main.tsx
+++ b/apps/dashboard/src/main.tsx
@@ -1,10 +1,11 @@
 import { createRoot } from "react-dom/client";
 import { DashboardProvider } from "@kitejs-cms/dashboard-core/dashboard-provider";
+import { GalleryModule } from "@kitejs-cms/gallery-dashboard";
 
 /* CSS */
 import "./index.css";
 import "@kitejs-cms/dashboard-core/styles.css";
 
 createRoot(document.getElementById("root")!).render(
-  <DashboardProvider modules={[]} />
+  <DashboardProvider modules={[GalleryModule]} />
 );

--- a/packages/gallery-dashboard/eslint.config.mjs
+++ b/packages/gallery-dashboard/eslint.config.mjs
@@ -1,0 +1,4 @@
+import { config } from "../eslint-config/react-internal.js";
+
+/** @type {import("eslint").Linter.Config} */
+export default config;

--- a/packages/gallery-dashboard/package.json
+++ b/packages/gallery-dashboard/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@kitejs-cms/gallery-dashboard",
+  "version": "0.1.0-alpha.0",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsc -b",
+    "dev": "tsc -b --watch",
+    "lint": "eslint src --ext .ts,.tsx --max-warnings 0"
+  },
+  "peerDependencies": {
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  },
+  "dependencies": {
+    "@kitejs-cms/dashboard-core": "workspace:*",
+    "lucide-react": "^0.475.0"
+  },
+  "devDependencies": {
+    "@kitejs-cms/eslint-config": "workspace:*",
+    "@kitejs-cms/typescript-config": "workspace:*",
+    "@types/react": "19.0.8",
+    "@types/react-dom": "19.0.3",
+    "eslint": "^9.20.0",
+    "typescript": "5.7.3"
+  }
+}

--- a/packages/gallery-dashboard/src/index.ts
+++ b/packages/gallery-dashboard/src/index.ts
@@ -1,0 +1,1 @@
+export { GalleryModule } from "./module";

--- a/packages/gallery-dashboard/src/locales/en.json
+++ b/packages/gallery-dashboard/src/locales/en.json
@@ -1,0 +1,5 @@
+{
+  "menu": {
+    "galleries": "Galleries"
+  }
+}

--- a/packages/gallery-dashboard/src/locales/it.json
+++ b/packages/gallery-dashboard/src/locales/it.json
@@ -1,0 +1,5 @@
+{
+  "menu": {
+    "galleries": "Gallerie"
+  }
+}

--- a/packages/gallery-dashboard/src/module.tsx
+++ b/packages/gallery-dashboard/src/module.tsx
@@ -1,0 +1,31 @@
+import { Image } from "lucide-react";
+import type { DashboardModule } from "@kitejs-cms/dashboard-core/models/module.model";
+import { GalleriesManagePage } from "./pages/galleries-manage";
+
+/* i18n */
+import it from "./locales/it.json";
+import en from "./locales/en.json";
+
+export const GalleryModule: DashboardModule = {
+  key: "gallery",
+  name: "gallery",
+  translations: { it, en },
+  routes: [
+    {
+      path: "galleries",
+      element: <GalleriesManagePage />,
+      label: "gallery:menu.galleries",
+    },
+  ],
+  menuItem: {
+    title: "gallery:menu.galleries",
+    icon: Image,
+    items: [
+      {
+        url: "/galleries",
+        title: "gallery:menu.galleries",
+        icon: Image,
+      },
+    ],
+  },
+};

--- a/packages/gallery-dashboard/src/pages/galleries-manage.tsx
+++ b/packages/gallery-dashboard/src/pages/galleries-manage.tsx
@@ -1,0 +1,27 @@
+import { useEffect, useState } from "react";
+
+interface Gallery {
+  id: string;
+}
+
+export function GalleriesManagePage() {
+  const [galleries, setGalleries] = useState<Gallery[]>([]);
+
+  useEffect(() => {
+    fetch("/api/galleries")
+      .then((res) => res.json())
+      .then((data) => setGalleries(data?.data ?? []))
+      .catch(() => setGalleries([]));
+  }, []);
+
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl font-bold mb-4">Galleries</h1>
+      <ul>
+        {galleries.map((g) => (
+          <li key={g.id}>{g.id}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/packages/gallery-dashboard/tsconfig.json
+++ b/packages/gallery-dashboard/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "@kitejs-cms/typescript-config/react-library.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "noImplicitAny": false,
+    "strictNullChecks": false,
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": false,
+    "strictPropertyInitialization": false,
+    "isolatedModules": false,
+    "skipLibCheck": true,
+    "module": "ES2022",
+    "esModuleInterop": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary
- create `@kitejs-cms/gallery-dashboard` package exporting a gallery module for the dashboard