### PR TITLE
feat(gallery): add creation and edit views

### DIFF
--- a/packages/gallery-dashboard/src/locales/en.json
+++ b/packages/gallery-dashboard/src/locales/en.json
@@ -8,7 +8,9 @@
   },
   "title": {
     "manageGalleries": "Galleries",
-    "noGalleries": "No galleries available"
+    "noGalleries": "No galleries available",
+    "createGallery": "Create Gallery",
+    "editGallery": "Edit Gallery"
   },
   "fields": {
     "slug": "Slug",
@@ -22,6 +24,9 @@
   "buttons": {
     "create": "Create",
     "addGallery": "Add Gallery",
+    "save": "Save",
+    "uploadImage": "Upload image",
+    "deleteGallery": "Delete Gallery",
     "copy": "Copy",
     "download": "Download",
     "delete": "Delete",

--- a/packages/gallery-dashboard/src/locales/it.json
+++ b/packages/gallery-dashboard/src/locales/it.json
@@ -8,7 +8,9 @@
   },
   "title": {
     "manageGalleries": "Gallerie",
-    "noGalleries": "Nessuna galleria disponibile"
+    "noGalleries": "Nessuna galleria disponibile",
+    "createGallery": "Crea Galleria",
+    "editGallery": "Modifica Galleria"
   },
   "fields": {
     "slug": "Slug",
@@ -22,6 +24,9 @@
   "buttons": {
     "create": "Crea",
     "addGallery": "Aggiungi Galleria",
+    "save": "Salva",
+    "uploadImage": "Carica immagine",
+    "deleteGallery": "Elimina Galleria",
     "copy": "Copia",
     "download": "Download",
     "delete": "Elimina",

--- a/packages/gallery-dashboard/src/module.tsx
+++ b/packages/gallery-dashboard/src/module.tsx
@@ -1,6 +1,8 @@
 import { Image } from "lucide-react";
 import type { DashboardModule } from "@kitejs-cms/dashboard-core";
 import { GalleriesManagePage } from "./pages/galleries-manage";
+import { GalleryCreatePage } from "./pages/gallery-create";
+import { GalleryEditPage } from "./pages/gallery-edit";
 
 /* i18n */
 import it from "./locales/it.json";
@@ -16,6 +18,8 @@ export const GalleryModule: DashboardModule = {
       element: <GalleriesManagePage />,
       label: "gallery:menu.galleries",
     },
+    { path: "galleries/create", element: <GalleryCreatePage /> },
+    { path: "galleries/:id", element: <GalleryEditPage /> },
   ],
   menuItem: {
     title: "gallery:menu.galleries",

--- a/packages/gallery-dashboard/src/pages/gallery-create.tsx
+++ b/packages/gallery-dashboard/src/pages/gallery-create.tsx
@@ -1,0 +1,57 @@
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { useNavigate } from "react-router-dom";
+import {
+  Button,
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  Input,
+  useApi,
+} from "@kitejs-cms/dashboard-core";
+
+export function GalleryCreatePage() {
+  const { t, i18n } = useTranslation("gallery");
+  const navigate = useNavigate();
+  const { fetchData } = useApi<{ id: string }>();
+
+  const [slug, setSlug] = useState("");
+  const [title, setTitle] = useState("");
+
+  const handleSubmit = async () => {
+    const { data } = await fetchData("galleries", "POST", {
+      slug,
+      translations: {
+        [i18n.language]: { title },
+      },
+    });
+    if (data?.id) {
+      navigate(`/galleries/${data.id}`);
+    }
+  };
+
+  return (
+    <div className="p-4 flex justify-center">
+      <Card className="w-full max-w-xl">
+        <CardHeader>
+          <CardTitle>{t("title.createGallery")}</CardTitle>
+        </CardHeader>
+        <CardContent className="flex flex-col gap-4">
+          <Input
+            placeholder={t("fields.slug") as string}
+            value={slug}
+            onChange={(e) => setSlug(e.target.value)}
+          />
+          <Input
+            placeholder={t("fields.title") as string}
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+          />
+          <Button onClick={handleSubmit}>{t("buttons.save")}</Button>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+

--- a/packages/gallery-dashboard/src/pages/gallery-edit.tsx
+++ b/packages/gallery-dashboard/src/pages/gallery-edit.tsx
@@ -1,0 +1,141 @@
+import { ChangeEvent, useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { useParams, useNavigate } from "react-router-dom";
+import {
+  Button,
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  Input,
+  useApi,
+} from "@kitejs-cms/dashboard-core";
+
+interface GalleryItem {
+  id: string;
+  assetId: string;
+}
+
+interface Gallery {
+  id: string;
+  slug?: string;
+  translations: Record<string, { title?: string }>;
+  items: GalleryItem[];
+}
+
+export function GalleryEditPage() {
+  const { t, i18n } = useTranslation("gallery");
+  const { id } = useParams();
+  const navigate = useNavigate();
+  const { data, fetchData } = useApi<Gallery>();
+
+  const [slug, setSlug] = useState("");
+  const [title, setTitle] = useState("");
+  const [items, setItems] = useState<GalleryItem[]>([]);
+  const [dragIndex, setDragIndex] = useState<number | null>(null);
+
+  useEffect(() => {
+    fetchData(`galleries/${id}`);
+  }, [id, fetchData]);
+
+  useEffect(() => {
+    if (data) {
+      setSlug(data.slug || "");
+      setTitle(data.translations?.[i18n.language]?.title || "");
+      setItems(data.items || []);
+    }
+  }, [data, i18n.language]);
+
+  const handleSave = async () => {
+    await fetchData("galleries", "POST", {
+      id,
+      slug,
+      translations: {
+        [i18n.language]: { title },
+      },
+    });
+  };
+
+  const handleDelete = async () => {
+    const res = await fetchData(`galleries/${id}`, "DELETE");
+    if (res) {
+      navigate("/galleries");
+    }
+  };
+
+  const handleUpload = async (e: ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const form = new FormData();
+    form.append("file", file);
+    const { data: asset } = await fetchData("assets", "POST", form);
+    if (asset?.id) {
+      const { data: updated } = await fetchData(`galleries/${id}/items`, "POST", {
+        assetId: asset.id,
+      });
+      if (updated) {
+        setItems(updated.items);
+      }
+    }
+  };
+
+  const handleDragStart = (index: number) => setDragIndex(index);
+  const handleDrop = async (index: number) => {
+    if (dragIndex === null || dragIndex === index) return;
+    const reordered = [...items];
+    const [moved] = reordered.splice(dragIndex, 1);
+    reordered.splice(index, 0, moved);
+    setItems(reordered);
+    setDragIndex(null);
+    await fetchData(`galleries/${id}/items/sort`, "POST", {
+      itemIds: reordered.map((i) => i.id),
+    });
+  };
+
+  return (
+    <div className="p-4 flex justify-center">
+      <Card className="w-full max-w-2xl">
+        <CardHeader>
+          <CardTitle>{t("title.editGallery")}</CardTitle>
+        </CardHeader>
+        <CardContent className="flex flex-col gap-4">
+          <Input
+            placeholder={t("fields.slug") as string}
+            value={slug}
+            onChange={(e) => setSlug(e.target.value)}
+          />
+          <Input
+            placeholder={t("fields.title") as string}
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+          />
+          <div className="flex flex-col gap-2">
+            <label className="font-medium">{t("buttons.uploadImage")}</label>
+            <Input type="file" onChange={handleUpload} />
+            <ul className="flex flex-col gap-2 mt-2">
+              {items.map((item, index) => (
+                <li
+                  key={item.id}
+                  draggable
+                  onDragStart={() => handleDragStart(index)}
+                  onDragOver={(e) => e.preventDefault()}
+                  onDrop={() => handleDrop(index)}
+                  className="border rounded p-2 cursor-move bg-white"
+                >
+                  {item.assetId}
+                </li>
+              ))}
+            </ul>
+          </div>
+          <div className="flex gap-2">
+            <Button onClick={handleSave}>{t("buttons.save")}</Button>
+            <Button variant="destructive" onClick={handleDelete}>
+              {t("buttons.deleteGallery")}
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add create page for new galleries
- add edit page with image upload, settings and drag-drop sorting
- expose routes and translations for gallery management

## Testing
- `pnpm lint --filter @kitejs-cms/gallery-dashboard`
- `pnpm test` (no tests found)


------
https://chatgpt.com/codex/tasks/task_e_68a2218d38cc8328be7d1e80a236d132