### PR TITLE
feat: add missing dashboard translations

### DIFF
--- a/packages/dashboard-core/src/locales/en/components.json
+++ b/packages/dashboard-core/src/locales/en/components.json
@@ -14,11 +14,96 @@
   },
   "nav-user": {
     "account": "Account",
-    "settings": "Ssettings",
+    "settings": "Settings",
     "logout": "Log out"
   },
   "tags-input": {
     "placeholder": "Type and press Enter to add a tag",
     "removeAriaLabel": "Remove {{tag}}"
+  },
+  "multi-select": {
+    "placeholder": "Select options",
+    "removeAriaLabel": "Remove {{tag}}"
+  },
+  "file-uploader": {
+    "defaultFileName": "existing-file",
+    "existingFile": "Existing File",
+    "removeFile": "Remove file",
+    "uploadTitle": "Upload a file",
+    "uploadDescription": "Drag and drop or click to select",
+    "sizes": {
+      "bytes": "Bytes",
+      "kb": "KB",
+      "mb": "MB",
+      "gb": "GB"
+    }
+  },
+  "custom-field-builder": {
+    "fieldTypes": {
+      "text": "Text",
+      "textarea": "Textarea",
+      "richText": "Rich Text",
+      "number": "Number",
+      "boolean": "Boolean",
+      "date": "Date"
+    },
+    "general": {
+      "required": "Required",
+      "cancel": "Cancel",
+      "export": "Export",
+      "add": "Add",
+      "create": "Create",
+      "update": "Update",
+      "edit": "Edit",
+      "remove": "Remove",
+      "save": "Save"
+    },
+    "labels": {
+      "fieldKey": "Field Key",
+      "fieldLabel": "Label",
+      "fieldType": "Field Type",
+      "requiredField": "Required field",
+      "placeholder": "Placeholder",
+      "description": "Description",
+      "minLength": "Min Length",
+      "maxLength": "Max Length",
+      "pattern": "Pattern (RegEx)",
+      "minValue": "Min Value",
+      "maxValue": "Max Value"
+    },
+    "errors": {
+      "keyRequired": "Key is required",
+      "keyInvalidFormat": "Key must start with a letter and contain only letters, numbers and underscores",
+      "keyAlreadyExists": "This key is already in use",
+      "labelRequired": "Label is required",
+      "minLengthGreaterThanMax": "Min length cannot be greater than max length",
+      "minValueGreaterThanMax": "Min value cannot be greater than max value"
+    },
+    "placeholders": {
+      "fieldKey": "e.g. customField1",
+      "fieldLabel": "e.g. Custom Field",
+      "placeholder": "Sample text...",
+      "description": "Short description of the field...",
+      "pattern": "e.g. ^[A-Za-z]+$"
+    },
+    "titles": {
+      "customFields": "Custom Fields",
+      "newField": "New Field",
+      "editField": "Edit Field",
+      "validationRules": "Validation Rules",
+      "noCustomFields": "No custom fields",
+      "createFirstField": "Start by creating your first custom field"
+    },
+    "actions": {
+      "addField": "Add Field",
+      "createField": "Create Field",
+      "updateField": "Update Field"
+    },
+    "indicators": {
+      "min": "Min",
+      "max": "Max",
+      "pattern": "Pattern"
+    }
   }
 }
+

--- a/packages/dashboard-core/src/modules/articles/locales/en.json
+++ b/packages/dashboard-core/src/modules/articles/locales/en.json
@@ -1,1 +1,49 @@
-{}
+{
+  "menu": {
+    "articles": "Articles",
+    "categories": "Categories"
+  },
+  "breadcrumb": {
+    "home": "Home",
+    "categories": "Categories"
+  },
+  "title": {
+    "managePages": "Manage Categories"
+  },
+  "search": {
+    "placeholder": "Search categories..."
+  },
+  "sections": {
+    "details": "Details",
+    "settings": "Settings"
+  },
+  "settings": {
+    "title": "Category Settings",
+    "description": "Configure settings for article categories.",
+    "article-filds": {
+      "title": "Custom Fields"
+    }
+  },
+  "fields": {
+    "slug": "Slug",
+    "languages": "Languages",
+    "title": "Title",
+    "description": "Description",
+    "tags": "Tags",
+    "createdAt": "Created at",
+    "createdBy": "Created by",
+    "updatedBy": "Updated by",
+    "isActive": "Published",
+    "actions": "Actions"
+  },
+  "buttons": {
+    "viewJson": "View JSON",
+    "cancel": "Cancel",
+    "save": "Save",
+    "add": "Add Category",
+    "copy": "Copy",
+    "download": "Download",
+    "edit": "Edit"
+  }
+}
+

--- a/packages/dashboard-core/src/modules/pages/locales/en.json
+++ b/packages/dashboard-core/src/modules/pages/locales/en.json
@@ -1,1 +1,119 @@
-{}
+{
+  "breadcrumb": {
+    "home": "Home",
+    "pages": "Pages",
+    "articles": "Articles"
+  },
+  "title": {
+    "managePages": "Manage Pages",
+    "editor": "Page Editor"
+  },
+  "buttons": {
+    "edit": "Edit",
+    "viewJson": "View JSON",
+    "addPage": "Add Page",
+    "addPost": "Add Article",
+    "copy": "Copy to Clipboard",
+    "download": "Download",
+    "editVisual": "Page Editor",
+    "revisions": "Revisions",
+    "close": "Close",
+    "cancel": "Cancel",
+    "save": "Save",
+    "discardChanges": "Discard changes",
+    "undo": "Undo",
+    "delete": "Delete"
+  },
+  "menu": {
+    "pages": "Pages",
+    "usersList": "Users List"
+  },
+  "search": {
+    "placeholder": "Search Pages..."
+  },
+  "fields": {
+    "slug": "Slug",
+    "title": "Title",
+    "description": "Description",
+    "tags": "Tags",
+    "status": "Status",
+    "publishAt": "Publish Date",
+    "expireAt": "Expiration Date",
+    "actions": "Actions",
+    "languages": "Languages",
+    "createdBy": "Created By",
+    "updatedBy": "Updated By",
+    "categories": "Categories",
+    "image": "Image"
+  },
+  "status": {
+    "published": "Published",
+    "draft": "Draft",
+    "archived": "Archived"
+  },
+  "sections": {
+    "revisions": "Revisions",
+    "content": "Content",
+    "seo": "SEO",
+    "settings": "Settings"
+  },
+  "seo": {
+    "metaTitle": "Meta Title",
+    "metaDescription": "Meta Description",
+    "metaKeywords": "Meta Keywords",
+    "canonical": "Canonical URL"
+  },
+  "unsavedChanges": {
+    "warning": "You have unsaved changes—are you sure you want to continue?",
+    "title": "Unsaved changes",
+    "message": "There are unsaved changes. Proceeding will discard all changes."
+  },
+  "errors": {
+    "titleRequired": "Title is required",
+    "slugRequired": "Slug is required",
+    "saveFailed": "Save failed. Please try again.",
+    "invalidForm": "Invalid form",
+    "missingTranslation": "Missing translation"
+  },
+  "toast": {
+    "loading": "Loading...",
+    "success": {
+      "create": "Page created successfully",
+      "update": "Page updated successfully",
+      "description": "Title: {title}"
+    },
+    "error": {
+      "generic": "Error during operation",
+      "server": "Server error",
+      "validation": "Validation error"
+    },
+    "warning": {
+      "unsaved": "Unsaved changes",
+      "exit": "You are about to exit without saving"
+    },
+    "action": {
+      "undo": "Undo",
+      "retry": "Retry",
+      "dismiss": "Dismiss"
+    }
+  },
+  "editor": {
+    "saveStatus": {
+      "saving": "Saving...",
+      "saved": "Saved",
+      "error": "Error saving"
+    },
+    "validation": {
+      "requiredField": "Required field",
+      "invalidSlug": "Invalid slug",
+      "duplicateSlug": "Slug already exists"
+    }
+  },
+  "deleteDialog": {
+    "title": "Confirm deletion",
+    "message": "Are you sure you want to delete this item? This action cannot be undone.",
+    "messageWithNamePrefix": "Are you sure you want to delete",
+    "messageWithNameSuffix": "? This action cannot be undone."
+  }
+}
+


### PR DESCRIPTION
## Summary
- add missing English component translations and fix nav user label
- provide full English locales for dashboard pages and articles modules

## Testing
- `pnpm --filter @kitejs-cms/dashboard-core lint` *(fails: ESLint found too many warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a242f1568083289127894d87c09c53