### PR TITLE
feat(core): validate required environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,17 +39,25 @@ pnpm dev --filter @kitejs-cms/dashboard  # start dashboard
 
 ## Environment variables
 
-Create a `.env` file in the repository root:
+The backend validates required settings at startup. Define them in a `.env` file in the repository root:
+
+| Variable | Description | Default |
+| --- | --- | --- |
+| `API_PORT` | Port for the NestJS server | `3000` |
+| `API_DB_URL` | MongoDB connection string | **required** |
+| `API_SECRET` | Secret used to sign JWT tokens | **required** |
+| `API_CORS` | Comma-separated list of allowed origins | `http://localhost:5173` |
+
+Example `.env`:
 
 ```
 API_PORT=3000
-PORT=3000
 API_DB_URL=mongodb://localhost:27017/kite
 API_SECRET=change-me
 API_CORS=http://localhost:5173
 ```
 
-Adjust the values (database URL, CORS origins, secret keys) as needed.
+Adjust the values as needed.
 
 ## Starting the apps
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -57,7 +57,8 @@
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.2",
     "sharp": "^0.33.5",
-    "uuid": "^11.1.0"
+    "uuid": "^11.1.0",
+    "zod": "^3.24.2"
   },
   "devDependencies": {
     "@kitejs-cms/eslint-config": "workspace:*",

--- a/packages/core/src/common/utils/database.module.ts
+++ b/packages/core/src/common/utils/database.module.ts
@@ -8,7 +8,6 @@ export class DatabaseModule {
     return {
       module: DatabaseModule,
       imports: [
-        ConfigModule.forRoot({ isGlobal: true, envFilePath: ".env" }),
         MongooseModule.forRootAsync({
           imports: [ConfigModule],
           useFactory: (configService: ConfigService) => ({

--- a/packages/core/src/core.module.ts
+++ b/packages/core/src/core.module.ts
@@ -1,5 +1,6 @@
 import { Module, DynamicModule, Type } from "@nestjs/common";
 import { ConfigModule } from "@nestjs/config";
+import { validate } from "./env.validation";
 import { APP_INTERCEPTOR } from "@nestjs/core";
 import { DatabaseModule, ResponseInterceptor } from "./common";
 import { CacheModule } from "./modules/cache";
@@ -19,6 +20,7 @@ import "multer";
     ConfigModule.forRoot({
       isGlobal: true,
       envFilePath: ".env",
+      validate,
     }),
     DatabaseModule.register(),
     CacheModule,

--- a/packages/core/src/env.validation.ts
+++ b/packages/core/src/env.validation.ts
@@ -1,0 +1,19 @@
+import { z } from "zod";
+
+const envSchema = z.object({
+  API_PORT: z.coerce.number().default(3000),
+  API_DB_URL: z.string().url(),
+  API_SECRET: z.string().min(1),
+  API_CORS: z.string().default("http://localhost:5173"),
+});
+
+export function validate(config: Record<string, unknown>) {
+  const parsed = envSchema.safeParse(config);
+  if (!parsed.success) {
+    const formatted = parsed.error.issues
+      .map((issue) => `${issue.path.join('.')}: ${issue.message}`)
+      .join(', ');
+    throw new Error(`Config validation error: ${formatted}`);
+  }
+  return parsed.data;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -272,6 +272,9 @@ importers:
       uuid:
         specifier: ^11.1.0
         version: 11.1.0
+      zod:
+        specifier: ^3.24.2
+        version: 3.25.74
     devDependencies:
       '@kitejs-cms/eslint-config':
         specifier: workspace:*


### PR DESCRIPTION
## Summary
- validate API env vars with zod and make ConfigModule global
- rely on global ConfigModule in database module
- document required env vars and defaults

## Testing
- `pnpm lint --filter @kitejs-cms/core` *(fails: The requested module '@kitejs-cms/eslint-config/nest' does not provide an export named 'config')*
- `pnpm build --filter @kitejs-cms/core`


------
https://chatgpt.com/codex/tasks/task_e_68a24b80d6748328b0f4a1977524dfef