### PR TITLE
feat(settings): allow JSON payload for setting values

### DIFF
--- a/packages/core/src/modules/settings/dto/setting-response.dto.ts
+++ b/packages/core/src/modules/settings/dto/setting-response.dto.ts
@@ -29,7 +29,7 @@ export class SettingResponseDto {
 
   @ApiProperty({
     description: 'Value of the setting.',
-    example: { value: 10 },
+    example: { itemsPerPage: 10 },
   })
   @IsObject()
   @IsNotEmpty()

--- a/packages/core/src/modules/settings/settings.service.ts
+++ b/packages/core/src/modules/settings/settings.service.ts
@@ -119,11 +119,11 @@ export class SettingsService {
   /**
    * Update an existing setting or create it if it does not exist.
    */
-  async upsert(
+  async upsert<T = Record<string, unknown>>(
     namespace: string,
     key: string,
-    value: unknown
-  ): Promise<Setting> {
+    value: T
+  ): Promise<Setting<T>> {
     try {
       const updatedSetting = await this.settingModel
         .findOneAndUpdate(
@@ -133,7 +133,7 @@ export class SettingsService {
         )
         .exec();
 
-      const settingDataJson = updatedSetting.toJSON();
+      const settingDataJson = updatedSetting.toJSON() as unknown as Setting<T>;
 
       const cacheKey = this.generateCacheKey(key);
       await this.cache.set(namespace, cacheKey, settingDataJson);


### PR DESCRIPTION
## Summary
- allow settings values to be provided as JSON, parsing strings and validating
- type SettingsService.upsert generically
- update swagger examples to show JSON payloads