### PR TITLE
feat(gallery): add file upload endpoint

### DIFF
--- a/packages/gallery-plugin/src/gallery/gallery.module.ts
+++ b/packages/gallery-plugin/src/gallery/gallery.module.ts
@@ -3,12 +3,13 @@ import { MongooseModule } from "@nestjs/mongoose";
 import { Gallery, GallerySchema } from "./schemas/gallery.schema";
 import { GalleryController } from "./gallery.controller";
 import { GalleryService } from "./services/gallery.service";
-import { SlugRegistryModule } from "@kitejs-cms/core";
+import { SlugRegistryModule, StorageModule } from "@kitejs-cms/core";
 
 @Module({
   imports: [
     MongooseModule.forFeature([{ name: Gallery.name, schema: GallerySchema }]),
     SlugRegistryModule,
+    StorageModule,
   ],
   controllers: [GalleryController],
   providers: [GalleryService],

--- a/packages/gallery-plugin/src/types/express-multer.d.ts
+++ b/packages/gallery-plugin/src/types/express-multer.d.ts
@@ -1,0 +1,10 @@
+declare namespace Express {
+  namespace Multer {
+    interface File {
+      originalname: string;
+      mimetype: string;
+      size: number;
+      buffer: Buffer;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- allow uploading gallery item images via `POST /:id/items/upload`
- save gallery item images in storage under `galleries/<galleryId>`
- wire gallery module with storage service