### PR TITLE
feat: add missing gallery dashboard translations

### DIFF
--- a/packages/gallery-dashboard/src/locales/en.json
+++ b/packages/gallery-dashboard/src/locales/en.json
@@ -55,10 +55,17 @@
     "editGallery": "Edit Gallery",
     "cancel": "Cancel",
     "viewJson": "View JSON",
-    "discardChanges": "Discard changes"
+    "discardChanges": "Discard changes",
+    "clearFilters": "Clear filters"
   },
   "search": {
-    "placeholder": "Search galleries..."
+    "placeholder": "Search galleries...",
+    "minChars": "Enter at least 3 characters to search"
+  },
+  "filters": {
+    "active": "{{count}} active filters",
+    "applied": "Filters applied",
+    "removed": "Filters removed"
   },
   "status": {
     "published": "Published",

--- a/packages/gallery-dashboard/src/locales/it.json
+++ b/packages/gallery-dashboard/src/locales/it.json
@@ -55,10 +55,17 @@
     "editGallery": "Modifica galleria",
     "cancel": "Annulla",
     "viewJson": "Visualizza JSON",
-    "discardChanges": "Ignora modifiche"
+    "discardChanges": "Ignora modifiche",
+    "clearFilters": "Rimuovi filtri"
   },
   "search": {
-    "placeholder": "Cerca Gallerie..."
+    "placeholder": "Cerca Gallerie...",
+    "minChars": "Inserisci almeno 3 caratteri per cercare"
+  },
+  "filters": {
+    "active": "{{count}} filtri attivi",
+    "applied": "Filtri applicati",
+    "removed": "Filtri rimossi"
   },
   "status": {
     "published": "Pubblicata",

--- a/packages/gallery-dashboard/src/pages/galleries-manage.tsx
+++ b/packages/gallery-dashboard/src/pages/galleries-manage.tsx
@@ -195,7 +195,6 @@ export function GalleriesManagePage() {
       params.set("page", "1");
       setSearchParams(params);
     }
-    console.log("Filtri applicati", filters);
   };
 
   const handleCopy = () => {
@@ -261,7 +260,6 @@ export function GalleriesManagePage() {
       "DELETE"
     );
     if (data) {
-      console.log("Deleted", renderTitle(selectedForDelete.translations));
       setSelectedForDelete(null);
       fetchData(buildApiUrl(currentPage, searchInput, activeFilters));
     }
@@ -283,7 +281,7 @@ export function GalleriesManagePage() {
                     variant="secondary"
                     className="bg-blue-100 text-blue-800 text-xs"
                   >
-                    {activeFilterCount} filtri attivi
+                    {t("filters.active", { count: activeFilterCount })}
                   </Badge>
                 </div>
               )}
@@ -316,7 +314,7 @@ export function GalleriesManagePage() {
                   />
                   {searchInput.length > 0 && searchInput.length < 3 && (
                     <p className="text-xs text-muted-foreground mt-1">
-                      Inserisci almeno 3 caratteri per cercare
+                      {t("search.minChars")}
                     </p>
                   )}
                 </div>
@@ -339,7 +337,7 @@ export function GalleriesManagePage() {
                     {t("buttons.copy")}
                   </DropdownMenuItem>
                   <DropdownMenuItem
-                    onClick={() => console.log(t("buttons.download"))}
+                    onClick={() => {}}
                   >
                     <Download className="mr-2 h-4 w-4" />
                     {t("buttons.download")}
@@ -348,11 +346,10 @@ export function GalleriesManagePage() {
                     <DropdownMenuItem
                       onClick={() => {
                         setActiveFilters([]);
-                        console.log("Filtri rimossi");
                       }}
                     >
                       <Trash className="mr-2 h-4 w-4" />
-                      Rimuovi filtri
+                      {t("buttons.clearFilters")}
                     </DropdownMenuItem>
                   )}
                 </DropdownMenuContent>


### PR DESCRIPTION
## Summary
- replace hardcoded Italian text in gallery management with i18n keys
- add English and Italian locale strings for filter and search messages
- remove debugging console logs from gallery management page

## Testing
- `pnpm lint` *(fails: The requested module '@kitejs-cms/eslint-config/nest' does not provide an export named 'config')*
- `pnpm check-types` *(fails: cannot find module '@kitejs-cms/core' and other type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68a81b0bbab08328806ea784f98246e8