### PR TITLE
feat: expose gallery settings and preserve item ids

### DIFF
--- a/packages/gallery-dashboard/src/components/gallery-editor-modal.tsx
+++ b/packages/gallery-dashboard/src/components/gallery-editor-modal.tsx
@@ -36,7 +36,7 @@ import {
 } from "lucide-react";
 import type { GalleryItemModel } from "@kitejs-cms/gallery-plugin";
 
-type Item = GalleryItemModel & { id: string };
+type Item = GalleryItemModel;
 
 interface GridSettings {
   columns: string;

--- a/packages/gallery-dashboard/src/hooks/use-gallery-details.ts
+++ b/packages/gallery-dashboard/src/hooks/use-gallery-details.ts
@@ -9,18 +9,12 @@ import {
 import {
   type GalleryResponseModel,
   type GalleryTranslationModel,
-  type GalleryItemModel,
   type GalleryUpsertModel,
   type GalleryStatus,
+  type GallerySettingsModel,
 } from "@kitejs-cms/gallery-plugin";
 
-interface GalleryItem extends GalleryItemModel {
-  id: string;
-}
-
-type GalleryDetails = Omit<GalleryResponseModel, "items"> & {
-  items: GalleryItem[];
-};
+type GalleryDetails = GalleryResponseModel;
 
 export interface FormErrors {
   title?: string;
@@ -75,6 +69,15 @@ export function useGalleryDetails() {
         updatedAt: new Date(),
         createdBy: "",
         updatedBy: "",
+        settings: {
+          layout: "grid",
+          columns: 3,
+          gap: 0,
+          ratio: "16:9",
+          autoplay: false,
+          loop: false,
+          lightbox: true,
+        },
         translations: {
           [defaultLang]: {
             title: "",
@@ -175,6 +178,16 @@ export function useGalleryDetails() {
     [],
   );
 
+  const onGallerySettingsChange = useCallback(
+    (field: keyof GallerySettingsModel, value: string | number | boolean | null) => {
+      setData((prev) =>
+        prev ? { ...prev, settings: { ...prev.settings, [field]: value } } : prev,
+      );
+      setHasChanges(true);
+    },
+    [],
+  );
+
   const onAddLanguage = useCallback((lang: string) => {
     setData((prev) => {
       if (!prev) return prev;
@@ -228,7 +241,16 @@ export function useGalleryDetails() {
         : undefined,
       title: translation.title,
       description: translation.description,
-      items: data.items.map((it, idx) => ({ assetId: it.assetId, order: idx })),
+      items: data.items.map((it, idx) => ({
+        id: it.id,
+        assetId: it.assetId,
+        order: idx,
+        caption: it.caption,
+        altOverride: it.altOverride,
+        linkUrl: it.linkUrl,
+        visibility: it.visibility,
+      })),
+      settings: data.settings,
       seo: translation.seo,
     };
 
@@ -345,5 +367,6 @@ export function useGalleryDetails() {
     handleNavigation,
     closeUnsavedAlert,
     confirmDiscard,
+    onGallerySettingsChange,
   };
 }

--- a/packages/gallery-dashboard/src/pages/gallery-details.tsx
+++ b/packages/gallery-dashboard/src/pages/gallery-details.tsx
@@ -10,7 +10,10 @@ import { SettingsSection } from "../components/settings-section";
 import { UnsavedChangesDialog } from "../components/unsaved-changes-dialog";
 import { GalleryEditorModal } from "../components/gallery-editor-modal";
 import { useGalleryDetails } from "../hooks/use-gallery-details";
-import type { GalleryTranslationModel } from "@kitejs-cms/gallery-plugin";
+import type {
+  GalleryTranslationModel,
+  GallerySettingsModel,
+} from "@kitejs-cms/gallery-plugin";
 
 type SettingsChangeHandler = (
   field: "status" | "publishAt" | "expireAt" | "tags",
@@ -47,11 +50,23 @@ export function GalleryDetailsPage() {
     handleNavigation,
     closeUnsavedAlert,
     confirmDiscard,
+    onGallerySettingsChange,
   } = useGalleryDetails();
 
   useEffect(() => {
     if (searchParams.get("view") === "json") setJsonView(true);
   }, [searchParams]);
+
+  useEffect(() => {
+    if (data?.settings) {
+      setGridSettings({
+        layout: data.settings.layout || "grid",
+        columns: String(data.settings.columns ?? "0"),
+        gap: String(data.settings.gap ?? "0"),
+        ratio: data.settings.ratio || "16:9",
+      });
+    }
+  }, [data]);
 
   if (loading || !data) return <SkeletonPage />;
 
@@ -141,9 +156,12 @@ export function GalleryDetailsPage() {
         onSort={sortItems}
         onDelete={removeItem}
         gridSettings={gridSettings}
-        onGridChange={(field, value) =>
-          setGridSettings((prev) => ({ ...prev, [field]: value }))
-        }
+        onGridChange={(field, value) => {
+          setGridSettings((prev) => ({ ...prev, [field]: value }));
+          const parsed =
+            field === "columns" || field === "gap" ? Number(value) : value;
+          onGallerySettingsChange(field as keyof GallerySettingsModel, parsed);
+        }}
       />
     </div>
   );

--- a/packages/gallery-plugin/src/gallery/dto/gallery-item.dto.ts
+++ b/packages/gallery-plugin/src/gallery/dto/gallery-item.dto.ts
@@ -5,6 +5,12 @@ import { Exclude, Transform } from "class-transformer";
 import type { ObjectId } from "mongoose";
 
 export class GalleryItemDto implements GalleryItemModel {
+  @ApiPropertyOptional({ description: "Item ID", example: "60f7c0a2d3a8f009e6f0b7d1" })
+  @IsOptional()
+  @IsMongoId()
+  @Transform(({ obj, value }) => value ?? obj._id?.toString())
+  id!: string;
+
   @ApiProperty({ description: "Asset ID", example: "60f7c0a2d3a8f009e6f0b7d1" })
   @IsMongoId()
   @Transform(({ value }) => value.toString())

--- a/packages/gallery-plugin/src/gallery/dto/gallery-response.dto.ts
+++ b/packages/gallery-plugin/src/gallery/dto/gallery-response.dto.ts
@@ -5,6 +5,7 @@ import { Exclude, Type } from "class-transformer";
 import type { ObjectId } from "mongoose";
 import { ValidateNested } from "class-validator";
 import { GalleryItemDto } from "./gallery-item.dto";
+import { GallerySettingsDto } from "./gallery-settings.dto";
 
 export class GalleryResponseDto implements GalleryResponseModel {
   @ApiProperty()
@@ -29,6 +30,11 @@ export class GalleryResponseDto implements GalleryResponseModel {
   @ValidateNested({ each: true })
   @Type(() => GalleryItemDto)
   items: GalleryItemDto[];
+
+  @ApiProperty({ type: () => GallerySettingsDto, required: false })
+  @ValidateNested()
+  @Type(() => GallerySettingsDto)
+  settings?: GallerySettingsDto;
 
   @ApiProperty()
   createdBy: string;

--- a/packages/gallery-plugin/src/gallery/dto/gallery-settings.dto.ts
+++ b/packages/gallery-plugin/src/gallery/dto/gallery-settings.dto.ts
@@ -1,0 +1,39 @@
+import { ApiPropertyOptional } from "@nestjs/swagger";
+import { IsBoolean, IsIn, IsNumber, IsOptional, IsString } from "class-validator";
+
+export class GallerySettingsDto {
+  @ApiPropertyOptional({ enum: ["grid", "masonry", "slider"] })
+  @IsOptional()
+  @IsIn(["grid", "masonry", "slider"])
+  layout?: "grid" | "masonry" | "slider";
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsNumber()
+  columns?: number;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsNumber()
+  gap?: number;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  ratio?: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsBoolean()
+  autoplay?: boolean;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsBoolean()
+  loop?: boolean;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsBoolean()
+  lightbox?: boolean;
+}

--- a/packages/gallery-plugin/src/gallery/dto/gallery-upsert.dto.ts
+++ b/packages/gallery-plugin/src/gallery/dto/gallery-upsert.dto.ts
@@ -12,6 +12,7 @@ import {
 import { GalleryStatus } from "../models/gallery-status.enum";
 import { GalleryItemDto } from "./gallery-item.dto";
 import { GallerySeoDto } from "./gallery-seo.dto";
+import { GallerySettingsDto } from "./gallery-settings.dto";
 
 export class GalleryUpsertDto {
   @ApiPropertyOptional()
@@ -66,6 +67,12 @@ export class GalleryUpsertDto {
   @ValidateNested({ each: true })
   @Type(() => GalleryItemDto)
   items?: GalleryItemDto[];
+
+  @ApiPropertyOptional({ type: GallerySettingsDto })
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => GallerySettingsDto)
+  settings?: GallerySettingsDto;
 
   @ApiPropertyOptional({ type: GallerySeoDto })
   @IsOptional()

--- a/packages/gallery-plugin/src/gallery/index.ts
+++ b/packages/gallery-plugin/src/gallery/index.ts
@@ -3,6 +3,7 @@ export * from "./models/gallery-status.enum";
 export * from "./models/gallery-seo.model";
 export * from "./models/gallery-translation.model";
 export * from "./models/gallery-item.model";
+export * from "./models/gallery-settings.model";
 export * from "./models/gallery-upsert.model";
 export * from "./models/gallery-response.model";
 
@@ -12,6 +13,7 @@ export * from "./dto/gallery-seo.dto";
 export * from "./dto/gallery-upsert.dto";
 export * from "./dto/gallery-sort.dto";
 export * from "./dto/gallery-response.dto";
+export * from "./dto/gallery-settings.dto";
 
 /* Services */
 export * from "./services/gallery.service";

--- a/packages/gallery-plugin/src/gallery/models/gallery-item.model.ts
+++ b/packages/gallery-plugin/src/gallery/models/gallery-item.model.ts
@@ -1,4 +1,5 @@
 export interface GalleryItemModel {
+  id: string;
   assetId: string;
   order?: number;
   caption?: string;

--- a/packages/gallery-plugin/src/gallery/models/gallery-response.model.ts
+++ b/packages/gallery-plugin/src/gallery/models/gallery-response.model.ts
@@ -1,6 +1,7 @@
 import { GalleryStatus } from "./gallery-status.enum";
 import { GalleryTranslationModel } from "./gallery-translation.model";
 import { GalleryItemModel } from "./gallery-item.model";
+import { GallerySettingsModel } from "./gallery-settings.model";
 
 export interface GalleryResponseModel {
   id: string;
@@ -10,6 +11,7 @@ export interface GalleryResponseModel {
   expireAt?: Date;
   translations: Record<string, GalleryTranslationModel>;
   items: GalleryItemModel[];
+  settings?: GallerySettingsModel;
   createdBy: string;
   updatedBy: string;
   createdAt: Date;

--- a/packages/gallery-plugin/src/gallery/models/gallery-settings.model.ts
+++ b/packages/gallery-plugin/src/gallery/models/gallery-settings.model.ts
@@ -1,0 +1,9 @@
+export interface GallerySettingsModel {
+  layout?: 'grid' | 'masonry' | 'slider';
+  columns?: number | null;
+  gap?: number | null;
+  ratio?: string | null;
+  autoplay?: boolean | null;
+  loop?: boolean | null;
+  lightbox?: boolean | null;
+}

--- a/packages/gallery-plugin/src/gallery/models/gallery-upsert.model.ts
+++ b/packages/gallery-plugin/src/gallery/models/gallery-upsert.model.ts
@@ -1,6 +1,7 @@
 import { GallerySeoModel } from "./gallery-seo.model";
 import { GalleryStatus } from "./gallery-status.enum";
 import { GalleryItemModel } from "./gallery-item.model";
+import { GallerySettingsModel } from "./gallery-settings.model";
 
 export interface GalleryUpsertModel {
   id?: string;
@@ -13,6 +14,7 @@ export interface GalleryUpsertModel {
   title: string;
   description?: string;
   items?: GalleryItemModel[];
+  settings?: GallerySettingsModel;
   seo?: GallerySeoModel;
 }
 

--- a/packages/gallery-plugin/src/gallery/services/gallery.service.ts
+++ b/packages/gallery-plugin/src/gallery/services/gallery.service.ts
@@ -39,7 +39,7 @@ export class GalleryService {
 
     type BaseData = Pick<
       GalleryUpsertDto,
-      "status" | "tags" | "publishAt" | "expireAt" | "items"
+      "status" | "tags" | "publishAt" | "expireAt" | "items" | "settings"
     >;
 
     const baseData: BaseData = {
@@ -47,7 +47,17 @@ export class GalleryService {
       tags: rest.tags,
       publishAt: rest.publishAt,
       expireAt: rest.expireAt,
-      items: rest.items,
+      items:
+        rest.items?.map((item, idx) => ({
+          ...(item.id ? { _id: new Types.ObjectId(item.id) } : {}),
+          assetId: new Types.ObjectId(item.assetId),
+          order: item.order ?? idx,
+          caption: item.caption,
+          altOverride: item.altOverride,
+          linkUrl: item.linkUrl,
+          visibility: item.visibility,
+        })) as unknown as GalleryItemDto[],
+      settings: rest.settings,
     };
 
     let gallery: Gallery;


### PR DESCRIPTION
## Summary
- support gallery layout settings with new model and DTO
- keep existing item identifiers when saving galleries
- sync dashboard gallery editor with settings from backend

## Testing
- `pnpm lint --filter @kitejs-cms/gallery-plugin` *(fails: Cannot find package '@kitejs-cms/eslint-config')*
- `pnpm lint --filter @kitejs-cms/gallery-dashboard` *(fails: missing modules during build)*
- `pnpm check-types --filter @kitejs-cms/gallery-plugin`
- `pnpm check-types --filter @kitejs-cms/gallery-dashboard` *(fails: missing modules during build)*

------
https://chatgpt.com/codex/tasks/task_e_68a8a22080d08328b08af0a57b84d684