### PR TITLE
feat: add permission handling

### DIFF
--- a/packages/dashboard-core/src/components/app-sidebar.tsx
+++ b/packages/dashboard-core/src/components/app-sidebar.tsx
@@ -4,6 +4,7 @@ import { useAuthContext } from "../context/auth-context";
 import { Command, LayoutDashboard } from "lucide-react";
 import { NavMain } from "../components/nav-main";
 import { NavUser } from "../components/nav-user";
+import { useHasPermission } from "../hooks/use-has-permission";
 import {
   Sidebar,
   SidebarContent,
@@ -25,6 +26,21 @@ export function AppSidebar({
 }) {
   const { cmsSettings } = useSettingsContext();
   const { user } = useAuthContext();
+  const hasPermission = useHasPermission();
+
+  const filterItems = (list: ItemModule[]): ItemModule[] =>
+    list
+      .filter(
+        (item) =>
+          !item.requiredPermissions ||
+          hasPermission(item.requiredPermissions)
+      )
+      .map((item) => ({
+        ...item,
+        items: item.items ? filterItems(item.items as ItemModule[]) : undefined,
+      }));
+
+  const filteredItems = filterItems(items);
 
   const allItems = [
     {
@@ -35,7 +51,7 @@ export function AppSidebar({
           url: "/",
           icon: LayoutDashboard,
         },
-        ...items,
+        ...filteredItems,
       ],
     },
   ];

--- a/packages/dashboard-core/src/components/protected-route.tsx
+++ b/packages/dashboard-core/src/components/protected-route.tsx
@@ -1,0 +1,24 @@
+import { Navigate } from "react-router-dom";
+import { ReactNode } from "react";
+import { useHasPermission } from "../hooks/use-has-permission";
+
+interface ProtectedRouteProps {
+  requiredPermissions?: string | string[];
+  fallback?: ReactNode;
+  children: ReactNode;
+}
+
+export function ProtectedRoute({
+  requiredPermissions,
+  fallback = <Navigate to="/" replace />,
+  children,
+}: ProtectedRouteProps) {
+  const hasPermission = useHasPermission();
+  const allowed = hasPermission(requiredPermissions);
+
+  if (!allowed) {
+    return <>{fallback}</>;
+  }
+
+  return <>{children}</>;
+}

--- a/packages/dashboard-core/src/dashboard-provider.tsx
+++ b/packages/dashboard-core/src/dashboard-provider.tsx
@@ -13,6 +13,7 @@ import { CoreModule } from "./modules/core";
 import { PageModule } from "./modules/pages";
 import { PostModule } from "./modules/articles";
 import { DashboardPage } from "./modules/core/pages/dashboard";
+import { ProtectedRoute } from "./components/protected-route";
 
 interface DashboardRouterProps {
   modules?: DashboardModule[];
@@ -51,7 +52,11 @@ export function DashboardProvider({ modules = [] }: DashboardRouterProps) {
       <Route
         key={`${mod.name}-${route.path}`}
         path={route.path}
-        element={route.element}
+        element={
+          <ProtectedRoute requiredPermissions={route.requiredPermissions}>
+            {route.element}
+          </ProtectedRoute>
+        }
       />
     ))
   );

--- a/packages/dashboard-core/src/hooks/use-has-permission.ts
+++ b/packages/dashboard-core/src/hooks/use-has-permission.ts
@@ -1,0 +1,27 @@
+import { useAuthContext } from "../context/auth-context";
+
+/**
+ * Returns a function to verify if the current user has the specified permissions.
+ *
+ * @returns A function that accepts a permission or array of permissions and
+ * returns true if the user has them. By default all provided permissions must
+ * be present. Pass { every: false } to check if at least one permission is present.
+ */
+export function useHasPermission() {
+  const { user } = useAuthContext();
+
+  return (
+    permissions?: string | string[],
+    options: { every?: boolean } = {}
+  ): boolean => {
+    if (!permissions || (Array.isArray(permissions) && permissions.length === 0)) {
+      return true;
+    }
+
+    const required = Array.isArray(permissions) ? permissions : [permissions];
+    const userPermissions = user?.permissions ?? [];
+    const method = options.every === false ? "some" : "every";
+
+    return required[method]((perm) => userPermissions.includes(perm));
+  };
+}

--- a/packages/dashboard-core/src/index.ts
+++ b/packages/dashboard-core/src/index.ts
@@ -47,6 +47,8 @@ export * from "./hooks/use-mobile";
 export * from "./hooks/use-clipboard-table";
 export * from "./context/breadcrumb-context";
 export * from "./hooks/use-debounce";
+export * from "./hooks/use-has-permission";
+export * from "./components/protected-route";
 
 /* Context */
 export * from "./context/auth-context";

--- a/packages/plugin-gallery-dashboard/src/pages/galleries-manage.tsx
+++ b/packages/plugin-gallery-dashboard/src/pages/galleries-manage.tsx
@@ -14,6 +14,7 @@ import {
   useClipboardTable,
   useDebounce,
   useBreadcrumb,
+  useHasPermission,
   FilterModal,
   DropdownMenu,
   DropdownMenuContent,
@@ -79,6 +80,10 @@ export function GalleriesManagePage() {
     publishAt: string;
   }>();
   const { data, loading, fetchData, pagination } = useApi<Gallery[]>();
+  const hasPermission = useHasPermission();
+  const canCreate = hasPermission("gallery-plugin:galleries.create");
+  const canUpdate = hasPermission("gallery-plugin:galleries.update");
+  const canDelete = hasPermission("gallery-plugin:galleries.delete");
 
   const [showFilter, setShowFilter] = useState(false);
   const [showSearch, setShowSearch] = useState(false);
@@ -330,12 +335,14 @@ export function GalleriesManagePage() {
                   </Button>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent align="end">
-                  <DropdownMenuItem
-                    onClick={() => navigate(`/galleries/create`)}
-                  >
-                    <Plus className="mr-2 h-4 w-4" />
-                    {t("buttons.addGallery")}
-                  </DropdownMenuItem>
+                  {canCreate && (
+                    <DropdownMenuItem
+                      onClick={() => navigate(`/galleries/create`)}
+                    >
+                      <Plus className="mr-2 h-4 w-4" />
+                      {t("buttons.addGallery")}
+                    </DropdownMenuItem>
+                  )}
                   <DropdownMenuItem onClick={handleCopy}>
                     <Clipboard className="mr-2 h-4 w-4" />
                     {t("buttons.copy")}
@@ -399,39 +406,46 @@ export function GalleriesManagePage() {
               {
                 key: "id",
                 label: t("fields.actions"),
-                render: (_, row) => (
-                  <DropdownMenu>
-                    <DropdownMenuTrigger asChild>
-                      <Button
-                        variant="outline"
-                        size="icon"
-                        className="shadow-none"
-                      >
-                        <MoreVertical />
-                      </Button>
-                    </DropdownMenuTrigger>
-                    <DropdownMenuContent align="end">
-                      <DropdownMenuItem
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          navigate(`/galleries/${row.id}`);
-                        }}
-                      >
-                        <Edit className="mr-2 h-4 w-4" />
-                        {t("buttons.edit")}
-                      </DropdownMenuItem>
-                      <DropdownMenuItem
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          setSelectedForDelete(row);
-                        }}
-                      >
-                        <Trash className="mr-2 h-4 w-4" />
-                        {t("buttons.delete")}
-                      </DropdownMenuItem>
-                    </DropdownMenuContent>
-                  </DropdownMenu>
-                ),
+                render: (_, row) => {
+                  if (!canUpdate && !canDelete) return null;
+                  return (
+                    <DropdownMenu>
+                      <DropdownMenuTrigger asChild>
+                        <Button
+                          variant="outline"
+                          size="icon"
+                          className="shadow-none"
+                        >
+                          <MoreVertical />
+                        </Button>
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent align="end">
+                        {canUpdate && (
+                          <DropdownMenuItem
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              navigate(`/galleries/${row.id}`);
+                            }}
+                          >
+                            <Edit className="mr-2 h-4 w-4" />
+                            {t("buttons.edit")}
+                          </DropdownMenuItem>
+                        )}
+                        {canDelete && (
+                          <DropdownMenuItem
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              setSelectedForDelete(row);
+                            }}
+                          >
+                            <Trash className="mr-2 h-4 w-4" />
+                            {t("buttons.delete")}
+                          </DropdownMenuItem>
+                        )}
+                      </DropdownMenuContent>
+                    </DropdownMenu>
+                  );
+                },
               },
             ]}
             pagination={{


### PR DESCRIPTION
## Summary
- add `useHasPermission` hook and `ProtectedRoute` component
- filter sidebar and protect routes based on permissions
- gate gallery management actions behind permission checks

## Testing
- `pnpm lint --filter @kitejs-cms/dashboard-core --filter @kitejs-cms/plugin-gallery-dashboard` (fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.15.1.tgz)
- `pnpm check-types --filter @kitejs-cms/dashboard-core --filter @kitejs-cms/plugin-gallery-dashboard` (fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.15.1.tgz)

------
https://chatgpt.com/codex/tasks/task_e_68b9ef8dcbfc8328af6aab0dc6e82c44