### PR TITLE
feat(gallery): add custom fields settings

### DIFF
--- a/packages/plugin-gallery-api/src/constants.ts
+++ b/packages/plugin-gallery-api/src/constants.ts
@@ -1,4 +1,8 @@
-import { FieldDefinition, PermissionModel, SettingModel } from "@kitejs-cms/core";
+import {
+  FieldDefinition,
+  PermissionModel,
+  SettingModel,
+} from "@kitejs-cms/core";
 
 export const GALLERY_PLUGIN_NAMESPACE = "gallery-plugin";
 
@@ -39,4 +43,3 @@ export const GallerySetting: SettingModel<GalleryPluginSettingsModel>[] = [
     value: { customFields: [] },
   },
 ];
-

--- a/packages/plugin-gallery-api/src/constants.ts
+++ b/packages/plugin-gallery-api/src/constants.ts
@@ -1,4 +1,4 @@
-import { PermissionModel, SettingModel } from "@kitejs-cms/core";
+import { FieldDefinition, PermissionModel, SettingModel } from "@kitejs-cms/core";
 
 export const GALLERY_PLUGIN_NAMESPACE = "gallery-plugin";
 
@@ -27,5 +27,16 @@ export const GalleryPermissions: PermissionModel[] = [
   },
 ];
 
-export const GallerySetting: SettingModel[] = [];
+export const GALLERY_SETTINGS_KEY = `${GALLERY_PLUGIN_NAMESPACE}:gallery`;
+
+export type GalleryPluginSettingsModel = {
+  customFields?: FieldDefinition[];
+};
+
+export const GallerySetting: SettingModel<GalleryPluginSettingsModel>[] = [
+  {
+    key: GALLERY_SETTINGS_KEY,
+    value: { customFields: [] },
+  },
+];
 

--- a/packages/plugin-gallery-api/src/gallery/gallery.module.ts
+++ b/packages/plugin-gallery-api/src/gallery/gallery.module.ts
@@ -3,13 +3,18 @@ import { MongooseModule } from "@nestjs/mongoose";
 import { Gallery, GallerySchema } from "./schemas/gallery.schema";
 import { GalleryController } from "./gallery.controller";
 import { GalleryService } from "./services/gallery.service";
-import { SlugRegistryModule, StorageModule } from "@kitejs-cms/core";
+import {
+  SlugRegistryModule,
+  StorageModule,
+  SettingsModule,
+} from "@kitejs-cms/core";
 
 @Module({
   imports: [
     MongooseModule.forFeature([{ name: Gallery.name, schema: GallerySchema }]),
     SlugRegistryModule,
     StorageModule,
+    SettingsModule,
   ],
   controllers: [GalleryController],
   providers: [GalleryService],

--- a/packages/plugin-gallery-api/src/index.ts
+++ b/packages/plugin-gallery-api/src/index.ts
@@ -2,4 +2,3 @@ export * from "./gallery-plugin.module";
 export * from "./gallery";
 export * from "./plugin.config";
 export * from "./constants";
-

--- a/packages/plugin-gallery-dashboard/src/components/gallery-fields-settings.tsx
+++ b/packages/plugin-gallery-dashboard/src/components/gallery-fields-settings.tsx
@@ -3,7 +3,10 @@ import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Button, useSettingsContext } from "@kitejs-cms/dashboard-core";
 import { CustomFieldBuilder } from "@kitejs-cms/dashboard-core/components/custom-field-builder";
-import { GALLERY_PLUGIN_NAMESPACE, GALLERY_SETTINGS_KEY, type GalleryPluginSettingsModel } from "../../../plugin-gallery-api/dist";
+import { type GalleryPluginSettingsModel } from "../../../plugin-gallery-api";
+
+export const GALLERY_PLUGIN_NAMESPACE = "gallery-plugin";
+export const GALLERY_SETTINGS_KEY = `${GALLERY_PLUGIN_NAMESPACE}:gallery`;
 
 export function GalleryFieldsSettings() {
   const [fields, setFields] = useState<FieldDefinition[]>([]);
@@ -15,10 +18,9 @@ export function GalleryFieldsSettings() {
   useEffect(() => {
     const loadFields = async () => {
       try {
-        const { value } = await getSetting<{ value: GalleryPluginSettingsModel }>(
-          GALLERY_PLUGIN_NAMESPACE,
-          GALLERY_SETTINGS_KEY
-        );
+        const { value } = await getSetting<{
+          value: GalleryPluginSettingsModel;
+        }>(GALLERY_PLUGIN_NAMESPACE, GALLERY_SETTINGS_KEY);
         if (value?.customFields) {
           setFields(value.customFields);
         }
@@ -65,4 +67,3 @@ export function GalleryFieldsSettings() {
     </div>
   );
 }
-

--- a/packages/plugin-gallery-dashboard/src/components/gallery-fields-settings.tsx
+++ b/packages/plugin-gallery-dashboard/src/components/gallery-fields-settings.tsx
@@ -1,0 +1,68 @@
+import type { FieldDefinition } from "@kitejs-cms/core";
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Button, useSettingsContext } from "@kitejs-cms/dashboard-core";
+import { CustomFieldBuilder } from "@kitejs-cms/dashboard-core/components/custom-field-builder";
+import { GALLERY_PLUGIN_NAMESPACE, GALLERY_SETTINGS_KEY, type GalleryPluginSettingsModel } from "../../../plugin-gallery-api/dist";
+
+export function GalleryFieldsSettings() {
+  const [fields, setFields] = useState<FieldDefinition[]>([]);
+  const { getSetting, updateSetting, setHasUnsavedChanges, hasUnsavedChanges } =
+    useSettingsContext();
+  const { t } = useTranslation("core");
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    const loadFields = async () => {
+      try {
+        const { value } = await getSetting<{ value: GalleryPluginSettingsModel }>(
+          GALLERY_PLUGIN_NAMESPACE,
+          GALLERY_SETTINGS_KEY
+        );
+        if (value?.customFields) {
+          setFields(value.customFields);
+        }
+      } catch (error) {
+        console.error("Failed to load gallery fields:", error);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+    loadFields();
+  }, [getSetting]);
+
+  const handleChange = (newFields: FieldDefinition[]) => {
+    setFields(newFields);
+    setHasUnsavedChanges(true);
+  };
+
+  const handleSave = async () => {
+    try {
+      setIsLoading(true);
+      await updateSetting(GALLERY_PLUGIN_NAMESPACE, GALLERY_SETTINGS_KEY, {
+        customFields: fields,
+      });
+      setHasUnsavedChanges(false);
+    } catch (error) {
+      console.error("Failed to save gallery fields:", error);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  if (isLoading) {
+    return <div>{t("common.loading")}</div>;
+  }
+
+  return (
+    <div className="pb-16">
+      <CustomFieldBuilder value={fields} onChange={handleChange} />
+      <div className="fixed bottom-4 right-4 p-4">
+        <Button onClick={handleSave} disabled={!hasUnsavedChanges || isLoading}>
+          {t("common.save")}
+        </Button>
+      </div>
+    </div>
+  );
+}
+

--- a/packages/plugin-gallery-dashboard/src/hooks/use-gallery-details.ts
+++ b/packages/plugin-gallery-dashboard/src/hooks/use-gallery-details.ts
@@ -1,3 +1,4 @@
+import type { FormValues } from "@kitejs-cms/dashboard-core/components/custom-field-form";
 import { EMPTY_GALLERY, DEFAULT_SETTINGS } from "../constant/empty-gallery";
 import { useEffect, useState, useCallback, useMemo } from "react";
 import { useParams, useNavigate } from "react-router-dom";
@@ -8,16 +9,17 @@ import {
   useBreadcrumb,
   useSettingsContext,
 } from "@kitejs-cms/dashboard-core";
-import type { FormValues } from "@kitejs-cms/dashboard-core/components/custom-field-form";
 import {
   type GalleryResponseModel,
   type GalleryTranslationModel,
   type GalleryUpsertModel,
   type GallerySettingsModel,
-  GALLERY_PLUGIN_NAMESPACE,
-  GALLERY_SETTINGS_KEY,
   type GalleryPluginSettingsModel,
 } from "../../../plugin-gallery-api/dist";
+import {
+  GALLERY_PLUGIN_NAMESPACE,
+  GALLERY_SETTINGS_KEY,
+} from "../components/gallery-fields-settings";
 
 type GalleryDetails = GalleryResponseModel;
 
@@ -94,14 +96,13 @@ export function useGalleryDetails() {
   useEffect(() => {
     (async () => {
       try {
-        const { value } = await getSetting<{ value: GalleryPluginSettingsModel }>(
-          GALLERY_PLUGIN_NAMESPACE,
-          GALLERY_SETTINGS_KEY
-        );
+        const { value } = await getSetting<{
+          value: GalleryPluginSettingsModel;
+        }>(GALLERY_PLUGIN_NAMESPACE, GALLERY_SETTINGS_KEY);
         if (value?.customFields) {
           setCustomFields(value.customFields);
           const extracted: FormValues = {};
-          const record = (data as unknown) as Record<string, unknown> | null;
+          const record = data as unknown as Record<string, unknown> | null;
           value.customFields.forEach((field) => {
             if (record && record[field.key] !== undefined) {
               extracted[field.key] = record[field.key] as FormValues[string];

--- a/packages/plugin-gallery-dashboard/src/hooks/use-gallery-details.ts
+++ b/packages/plugin-gallery-dashboard/src/hooks/use-gallery-details.ts
@@ -2,17 +2,21 @@ import { EMPTY_GALLERY, DEFAULT_SETTINGS } from "../constant/empty-gallery";
 import { useEffect, useState, useCallback, useMemo } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import { useTranslation } from "react-i18next";
-import { UploadResultModel } from "@kitejs-cms/core";
+import { UploadResultModel, type FieldDefinition } from "@kitejs-cms/core";
 import {
   useApi,
   useBreadcrumb,
   useSettingsContext,
 } from "@kitejs-cms/dashboard-core";
+import type { FormValues } from "@kitejs-cms/dashboard-core/components/custom-field-form";
 import {
   type GalleryResponseModel,
   type GalleryTranslationModel,
   type GalleryUpsertModel,
   type GallerySettingsModel,
+  GALLERY_PLUGIN_NAMESPACE,
+  GALLERY_SETTINGS_KEY,
+  type GalleryPluginSettingsModel,
 } from "../../../plugin-gallery-api/dist";
 
 type GalleryDetails = GalleryResponseModel;
@@ -57,7 +61,7 @@ export function useGalleryDetails() {
   const navigate = useNavigate();
   const { id } = useParams() as { id?: string };
   const { setBreadcrumb } = useBreadcrumb();
-  const { cmsSettings } = useSettingsContext();
+  const { cmsSettings, getSetting } = useSettingsContext();
 
   const defaultLang = useMemo(
     () => cmsSettings?.defaultLanguage || "en",
@@ -72,6 +76,8 @@ export function useGalleryDetails() {
   const [showUnsavedAlert, setShowUnsavedAlert] = useState(false);
   const [navigateTo, setNavigateTo] = useState("");
   const [formErrors, setFormErrors] = useState<FormErrors>({});
+  const [customFields, setCustomFields] = useState<FieldDefinition[]>([]);
+  const [customFieldsValues, setCustomFieldsValues] = useState<FormValues>({});
 
   useEffect(() => {
     const crumbs = [
@@ -84,6 +90,32 @@ export function useGalleryDetails() {
     }
     setBreadcrumb(crumbs);
   }, [t, id, data, activeLang, setBreadcrumb]);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const { value } = await getSetting<{ value: GalleryPluginSettingsModel }>(
+          GALLERY_PLUGIN_NAMESPACE,
+          GALLERY_SETTINGS_KEY
+        );
+        if (value?.customFields) {
+          setCustomFields(value.customFields);
+          const extracted: FormValues = {};
+          const record = (data as unknown) as Record<string, unknown> | null;
+          value.customFields.forEach((field) => {
+            if (record && record[field.key] !== undefined) {
+              extracted[field.key] = record[field.key] as FormValues[string];
+            } else if (field.defaultValue !== undefined) {
+              extracted[field.key] = field.defaultValue as FormValues[string];
+            }
+          });
+          setCustomFieldsValues(extracted);
+        }
+      } catch (error) {
+        console.error("Failed to load custom fields:", error);
+      }
+    })();
+  }, [getSetting, data]);
 
   useEffect(() => {
     if (!defaultLang) return;
@@ -177,6 +209,14 @@ export function useGalleryDetails() {
     setHasChanges(true);
   }, []);
 
+  const onChangeCustomField = useCallback(
+    (values: FormValues) => {
+      setCustomFieldsValues((prev) => ({ ...prev, ...values }));
+      setHasChanges(true);
+    },
+    [setHasChanges]
+  );
+
   const onAddLanguage = useCallback((lang: string) => {
     setData((prev) => {
       if (!prev || prev.translations[lang]) return prev;
@@ -236,6 +276,7 @@ export function useGalleryDetails() {
       })),
       settings: data.settings,
       seo: translation.seo,
+      ...customFieldsValues,
     };
 
     const result = await fetchData(
@@ -251,7 +292,7 @@ export function useGalleryDetails() {
       setFormErrors({});
       if (id === "create") navigate(`/galleries/${updated.id}`);
     }
-  }, [data, activeLang, fetchData, id, navigate, t]);
+  }, [data, activeLang, customFieldsValues, fetchData, id, navigate, t]);
 
   const handleNavigation = useCallback(
     (path: string) => {
@@ -354,5 +395,8 @@ export function useGalleryDetails() {
     closeUnsavedAlert,
     confirmDiscard,
     onGallerySettingsChange,
+    customFields,
+    customFieldsValues,
+    onChangeCustomField,
   };
 }

--- a/packages/plugin-gallery-dashboard/src/locales/en.json
+++ b/packages/plugin-gallery-dashboard/src/locales/en.json
@@ -38,6 +38,12 @@
     "grid": "Grid settings",
     "preview": "Preview"
   },
+  "settings": {
+    "description": "Configure gallery settings.",
+    "gallery-fields": {
+      "title": "Custom Fields"
+    }
+  },
   "errors": {
     "titleRequired": "Title is required",
     "slugRequired": "Slug is required"

--- a/packages/plugin-gallery-dashboard/src/locales/it.json
+++ b/packages/plugin-gallery-dashboard/src/locales/it.json
@@ -38,6 +38,12 @@
     "grid": "Impostazioni griglia",
     "preview": "Anteprima"
   },
+  "settings": {
+    "description": "Configura le impostazioni della galleria.",
+    "gallery-fields": {
+      "title": "Campi personalizzati"
+    }
+  },
   "errors": {
     "titleRequired": "Il titolo è obbligatorio",
     "slugRequired": "Lo slug è obbligatorio"

--- a/packages/plugin-gallery-dashboard/src/module.tsx
+++ b/packages/plugin-gallery-dashboard/src/module.tsx
@@ -2,6 +2,7 @@ import { Image } from "lucide-react";
 import type { DashboardModule } from "@kitejs-cms/dashboard-core";
 import { GalleriesManagePage } from "./pages/galleries-manage";
 import { GalleryDetailsPage } from "./pages/gallery-details";
+import { GalleryFieldsSettings } from "./components/gallery-fields-settings";
 
 /* i18n */
 import it from "./locales/it.json";
@@ -11,6 +12,20 @@ export const GalleryModule: DashboardModule = {
   key: "gallery",
   name: "gallery",
   translations: { it, en },
+  settings: {
+    key: "gallery",
+    title: "gallery:menu.galleries",
+    icon: <Image />,
+    description: "gallery:settings.description",
+    children: [
+      {
+        key: "gallery-fields",
+        title: "gallery:settings.gallery-fields.title",
+        icon: <Image />,
+        component: <GalleryFieldsSettings />,
+      },
+    ],
+  },
   routes: [
     {
       path: "galleries",

--- a/packages/plugin-gallery-dashboard/src/pages/gallery-details.tsx
+++ b/packages/plugin-gallery-dashboard/src/pages/gallery-details.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { Button, SkeletonPage } from "@kitejs-cms/dashboard-core";
+import { CustomFieldForm } from "@kitejs-cms/dashboard-core/components/custom-field-form";
 import { JsonModal } from "@kitejs-cms/dashboard-core/components/json-modal";
 import { LanguageTabs } from "../components/language-tabs";
 import { ContentSection } from "../components/content-section";
@@ -44,6 +45,9 @@ export function GalleryDetailsPage() {
     closeUnsavedAlert,
     confirmDiscard,
     onGallerySettingsChange,
+    customFields,
+    customFieldsValues,
+    onChangeCustomField,
   } = useGalleryDetails();
 
   useEffect(() => {
@@ -110,6 +114,15 @@ export function GalleryDetailsPage() {
             onChange={onSettingsChange as SettingsChangeHandler}
             onViewJson={() => setJsonView(true)}
           />
+          {customFields.length > 0 && (
+            <CustomFieldForm
+              title={t("settings.gallery-fields.title")}
+              fields={customFields}
+              values={customFieldsValues}
+              onChange={onChangeCustomField}
+              errors={{}}
+            />
+          )}
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- add plugin-level gallery custom field settings and model
- support custom fields in gallery service and dashboard editor
- expose gallery fields settings page with translations