### PR TITLE
fix: infer setting type from namespace

### DIFF
--- a/packages/core/src/modules/plugins/services/plugins-loader.service.ts
+++ b/packages/core/src/modules/plugins/services/plugins-loader.service.ts
@@ -9,7 +9,7 @@ import {
   RolesService,
   PermissionResponseModel,
 } from "../../users";
-import { SettingsService, SettingType } from "../../settings";
+import { SettingsService } from "../../settings";
 
 @Injectable()
 export class PluginsLoaderService {
@@ -73,10 +73,9 @@ export class PluginsLoaderService {
                 namespace: pluginInstance.namespace,
                 key: setting.key,
                 value: setting.value,
-                type:
-                  pluginInstance.namespace === "core"
-                    ? SettingType.CORE
-                    : SettingType.PLUGIN,
+                type: this.settingService.getSettingType(
+                  pluginInstance.namespace
+                ),
               });
             }
           }


### PR DESCRIPTION
## Summary
- infer setting type from namespace to support core, plugin, theme or other settings
- apply derived type during setting creation and upsert
- use same helper when plugins create default settings