### PR TITLE
feat: add user settings section

### DIFF
--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -4,6 +4,7 @@ import {
   CACHE_SETTINGS_KEY,
   SWAGGER_SETTINGS_KEY,
   STORAGE_SETTINGS_KEY,
+  USER_SETTINGS_KEY,
   SettingModel,
 } from "./modules/settings";
 import {
@@ -235,5 +236,12 @@ export const CoreSetting: SettingModel[] = [
   {
     key: PAGE_SETTINGS_KEY,
     value: { filterFields: PageFilterFields, views: PageViews },
+  },
+  {
+    key: USER_SETTINGS_KEY,
+    value: {
+      registrationOpen: true,
+      defaultRole: "user",
+    },
   },
 ];

--- a/packages/core/src/modules/settings/index.ts
+++ b/packages/core/src/modules/settings/index.ts
@@ -8,6 +8,7 @@ export * from "./models/init-cms.model";
 export * from "./models/cms-settings.model";
 export * from "./models/storage-settings.model";
 export * from "./models/article-settings.models";
+export * from "./models/user-settings.model";
 
 /* Dto */
 export * from "./dto/init-cms.dto";

--- a/packages/core/src/modules/settings/models/user-settings.model.ts
+++ b/packages/core/src/modules/settings/models/user-settings.model.ts
@@ -1,0 +1,6 @@
+export const USER_SETTINGS_KEY = "core:users";
+
+export type UserSettingsModel = {
+  registrationOpen: boolean;
+  defaultRole: string;
+};

--- a/packages/dashboard-core/src/locales/en/users.json
+++ b/packages/dashboard-core/src/locales/en/users.json
@@ -59,5 +59,11 @@
     "required": "This field is required.",
     "invalidEmail": "Invalid email address.",
     "passwordMin": "Password must be at least 8 characters."
+  },
+  "settings": {
+    "title": "User Settings",
+    "description": "Configure user registration and default role.",
+    "registrationOpen": "Allow registration",
+    "defaultRole": "Default role"
   }
 }

--- a/packages/dashboard-core/src/locales/it/users.json
+++ b/packages/dashboard-core/src/locales/it/users.json
@@ -59,5 +59,11 @@
     "required": "Questo campo è obbligatorio.",
     "invalidEmail": "E-mail non valida.",
     "passwordMin": "La password deve essere lunga almeno 8 caratteri."
+  },
+  "settings": {
+    "title": "Impostazioni Utenti",
+    "description": "Configura la registrazione e il ruolo predefinito.",
+    "registrationOpen": "Permetti registrazione",
+    "defaultRole": "Ruolo predefinito"
   }
 }

--- a/packages/dashboard-core/src/modules/users/components/user-settings.tsx
+++ b/packages/dashboard-core/src/modules/users/components/user-settings.tsx
@@ -1,0 +1,98 @@
+import { useEffect } from "react";
+import { z } from "zod";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useTranslation } from "react-i18next";
+import { useSettingsContext } from "../../../context/settings-context";
+import { Form, FormField, FormItem, FormLabel, FormControl, FormMessage } from "../../../components/ui/form";
+import { Switch } from "../../../components/ui/switch";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "../../../components/ui/select";
+import { Button } from "../../../components/ui/button";
+import { useApi } from "../../../hooks/use-api";
+import { RoleResponseModel } from "@kitejs-cms/core/modules/users/models/role-response.model";
+
+const formSchema = z.object({
+  registrationOpen: z.boolean(),
+  defaultRole: z.string().min(1),
+});
+
+type UserSettingsForm = z.infer<typeof formSchema>;
+
+export function UserSettings() {
+  const { t } = useTranslation("users");
+  const { getSetting, updateSetting, setHasUnsavedChanges } = useSettingsContext();
+  const { data: roles, fetchData } = useApi<RoleResponseModel[]>();
+
+  const form = useForm<UserSettingsForm>({
+    resolver: zodResolver(formSchema),
+    defaultValues: { registrationOpen: true, defaultRole: "" },
+  });
+
+  const { handleSubmit, reset, formState: { isDirty } } = form;
+
+  useEffect(() => {
+    setHasUnsavedChanges(isDirty);
+  }, [isDirty, setHasUnsavedChanges]);
+
+  useEffect(() => {
+    (async () => {
+      const setting = await getSetting<{ value: UserSettingsForm }>("core", "core:users");
+      if (setting?.value) {
+        reset(setting.value);
+      }
+      fetchData("roles");
+    })();
+  }, [getSetting, reset, fetchData]);
+
+  const onSubmit = async (values: UserSettingsForm) => {
+    await updateSetting("core", "core:users", values);
+    reset(values);
+    setHasUnsavedChanges(false);
+  };
+
+  return (
+    <Form {...form}>
+      <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
+        <FormField
+          control={form.control}
+          name="registrationOpen"
+          render={({ field }) => (
+            <FormItem className="flex flex-row items-center justify-between rounded-lg border p-4">
+              <FormLabel>{t("settings.registrationOpen")}</FormLabel>
+              <FormControl>
+                <Switch checked={field.value} onCheckedChange={field.onChange} />
+              </FormControl>
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="defaultRole"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>{t("settings.defaultRole")}</FormLabel>
+              <Select value={field.value} onValueChange={field.onChange}>
+                <FormControl>
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                </FormControl>
+                <SelectContent>
+                  {roles?.map((role) => (
+                    <SelectItem key={role.id} value={role.name}>
+                      {role.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <div className="flex justify-end">
+          <Button type="submit">{t("buttons.save")}</Button>
+        </div>
+      </form>
+    </Form>
+  );
+}

--- a/packages/dashboard-core/src/modules/users/index.tsx
+++ b/packages/dashboard-core/src/modules/users/index.tsx
@@ -4,6 +4,7 @@ import { UserPlus, Users, UsersIcon, Shield } from "lucide-react";
 import { UsersManagePage } from "./pages/users-manage";
 import { RolesManagePage } from "./pages/roles-manage";
 import { UserProfilePage } from "./pages/user-profile";
+import { UserSettings } from "./components/user-settings";
 
 export const UsersModule: DashboardModule = {
   name: "users",
@@ -47,25 +48,11 @@ export const UsersModule: DashboardModule = {
       },
     ],
   },
-  //settings: {
-  //  key: "users",
-  //  title: "users:settings.title",
-  //  icon: <Users />,
-  //  description: "users:settings.description",
-  //  component: <div>Main</div>,
-  //  children: [
-  //    {
-  //      key: "users-management",
-  //      title: "users:settings.usersManagement",
-  //      icon: <UserPlus />,
-  //      component: <div>TEST</div>,
-  //    },
-  //    {
-  //      key: "roles",
-  //      title: "users:settings.roles",
-  //      icon: <Shield />,
-  //      component: <div>TEST2</div>,
-  //    },
-  //  ],
-  //},
+  settings: {
+    key: "users",
+    title: "users:settings.title",
+    icon: <Users />,
+    description: "users:settings.description",
+    component: <UserSettings />,
+  },
 };


### PR DESCRIPTION
## Summary
- add user settings model and defaults in core
- expose user settings management in dashboard
- localize new user settings strings

## Testing
- `pnpm lint` *(fails: @kitejs-cms/plugin-gallery-api build cannot find module '@kitejs-cms/core')*
- `pnpm --filter @kitejs-cms/core lint` *(passes with warnings)*
- `pnpm --filter @kitejs-cms/dashboard-core lint` *(fails: ESLint found too many warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68bbf2f2a7a08328817657b066d2fb0c