### PR TITLE
feat: show skeleton while loading consents

### DIFF
--- a/packages/dashboard-core/src/modules/articles/components/article-filds-settings.tsx
+++ b/packages/dashboard-core/src/modules/articles/components/article-filds-settings.tsx
@@ -2,6 +2,7 @@ import type { FieldDefinition } from "@kitejs-cms/core/index";
 import { CustomFieldBuilder } from "../../../components/custom-field-builder";
 import { useEffect, useState } from "react";
 import { Button } from "../../../components/ui/button";
+import { Skeleton } from "../../../components/ui/skeleton";
 import { useTranslation } from "react-i18next";
 import { useSettingsContext } from "../../../context/settings-context";
 
@@ -52,7 +53,12 @@ export function ArticleFieldsSettings() {
   };
 
   if (isLoading) {
-    return <div>{t("common.loading", "Loading...")}</div>;
+    return (
+      <div className="space-y-6">
+        <Skeleton className="h-40 w-full" />
+        <Skeleton className="h-10 w-24 ml-auto" />
+      </div>
+    );
   }
 
   return (

--- a/packages/dashboard-core/src/modules/users/components/user-consents-settings.tsx
+++ b/packages/dashboard-core/src/modules/users/components/user-consents-settings.tsx
@@ -8,6 +8,7 @@ import { Switch } from "../../../components/ui/switch";
 import { Label } from "../../../components/ui/label";
 import { Trash2 } from "lucide-react";
 import { UserSettingsModel } from "@kitejs-cms/core/modules/settings/models/user-settings.model";
+import { Skeleton } from "../../../components/ui/skeleton";
 
 export function UserConsentSettings() {
   const { t } = useTranslation("users");
@@ -99,7 +100,28 @@ export function UserConsentSettings() {
   };
 
   if (isLoading) {
-    return <div>{t("common.loading", "Loading...")}</div>;
+    return (
+      <div className="space-y-6">
+        <div className="flex flex-row items-center justify-between rounded-lg border p-4">
+          <Skeleton className="h-4 w-40" />
+          <Skeleton className="h-6 w-10" />
+        </div>
+        <div className="space-y-4">
+          {[0, 1].map((i) => (
+            <div key={i} className="space-y-2 rounded-lg border p-4">
+              <Skeleton className="h-4 w-1/2" />
+              <Skeleton className="h-4 w-full" />
+              <Skeleton className="h-4 w-1/3" />
+              <Skeleton className="h-4 w-full" />
+              <div className="flex items-center justify-between rounded-lg border p-2">
+                <Skeleton className="h-4 w-1/3" />
+                <Skeleton className="h-6 w-10" />
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    );
   }
 
   return (

--- a/packages/dashboard-core/src/modules/users/components/user-general-settings.tsx
+++ b/packages/dashboard-core/src/modules/users/components/user-general-settings.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { z } from "zod";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -24,6 +24,7 @@ import { Button } from "../../../components/ui/button";
 import { useApi } from "../../../hooks/use-api";
 import { RoleResponseModel } from "@kitejs-cms/core/modules/users/models/role-response.model";
 import { UserSettingsModel } from "@kitejs-cms/core/modules/settings/models/user-settings.model";
+import { Skeleton } from "../../../components/ui/skeleton";
 
 const formSchema = z.object({
   registrationOpen: z.boolean(),
@@ -37,6 +38,7 @@ export function UserGeneralSettings() {
   const { getSetting, updateSetting, setHasUnsavedChanges } =
     useSettingsContext();
   const { data: roles, fetchData } = useApi<RoleResponseModel[]>();
+  const [isLoading, setIsLoading] = useState(true);
 
   const form = useForm<GeneralSettingsForm>({
     resolver: zodResolver(formSchema),
@@ -69,7 +71,8 @@ export function UserGeneralSettings() {
           defaultRole: setting.value.defaultRole,
         });
       }
-      fetchData("roles");
+      await fetchData("roles");
+      setIsLoading(false);
     })();
   }, [getSetting, reset, fetchData]);
 
@@ -91,6 +94,21 @@ export function UserGeneralSettings() {
     reset(values);
     setHasUnsavedChanges(false);
   };
+
+  if (isLoading) {
+    return (
+      <div className="space-y-6">
+        <div className="flex flex-row items-center justify-between rounded-lg border p-4">
+          <Skeleton className="h-4 w-40" />
+          <Skeleton className="h-6 w-10" />
+        </div>
+        <div className="space-y-2">
+          <Skeleton className="h-4 w-40" />
+          <Skeleton className="h-10 w-full" />
+        </div>
+      </div>
+    );
+  }
 
   return (
     <Form {...form}>

--- a/packages/dashboard-core/src/modules/users/pages/user-profile.tsx
+++ b/packages/dashboard-core/src/modules/users/pages/user-profile.tsx
@@ -50,6 +50,7 @@ export function UserProfilePage() {
   const isAdmin = currentUser?.roles?.includes("admin");
   const { getSetting } = useSettingsContext();
   const [consentsEnabled, setConsentsEnabled] = useState(false);
+  const [consentsLoading, setConsentsLoading] = useState(true);
   const [consentDefinitions, setConsentDefinitions] = useState<
     UserSettingsModel["consents"] | undefined
   >(undefined);
@@ -105,12 +106,14 @@ export function UserProfilePage() {
 
   useEffect(() => {
     (async () => {
+      setConsentsLoading(true);
       const setting = await getSetting<{ value: UserSettingsModel }>(
         "core",
         "core:users"
       );
       setConsentsEnabled(setting?.value?.consentsEnabled ?? false);
       setConsentDefinitions(setting?.value?.consents || []);
+      setConsentsLoading(false);
     })();
   }, [getSetting]);
 
@@ -144,7 +147,11 @@ export function UserProfilePage() {
       />
 
       <div className="flex flex-col lg:flex-row lg:items-start gap-4">
-        <Card className="w-full lg:w-3/4 shadow-neutral-50 gap-0 py-0">
+        <Card
+          className={`w-full ${
+            consentsEnabled || consentsLoading ? "lg:w-3/4" : "lg:w-full"
+          } shadow-neutral-50 gap-0 py-0`}
+        >
           <CardHeader className="bg-neutral-50 py-4 rounded-t-xl">
             <div className="flex items-center justify-between">
               <CardTitle>
@@ -267,15 +274,19 @@ export function UserProfilePage() {
           </CardContent>
         </Card>
 
-        {consentsEnabled && id && (
-          <UserConsentsCard
-            userId={id}
-            consents={user?.consents}
-            definitions={consentDefinitions}
-            loading={!user}
-            canEdit={!!isAdmin}
-            onUpdated={() => fetchUser(`users/${id}`)}
-          />
+        {consentsLoading ? (
+          <UserConsentsCard userId={id || ""} loading />
+        ) : (
+          consentsEnabled && id && (
+            <UserConsentsCard
+              userId={id}
+              consents={user?.consents}
+              definitions={consentDefinitions}
+              loading={!user}
+              canEdit={!!isAdmin}
+              onUpdated={() => fetchUser(`users/${id}`)}
+            />
+          )
         )}
       </div>
 

--- a/packages/plugin-gallery-dashboard/src/components/gallery-fields-settings.tsx
+++ b/packages/plugin-gallery-dashboard/src/components/gallery-fields-settings.tsx
@@ -1,7 +1,7 @@
 import type { FieldDefinition } from "@kitejs-cms/core";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Button, useSettingsContext } from "@kitejs-cms/dashboard-core";
+import { Button, Skeleton, useSettingsContext } from "@kitejs-cms/dashboard-core";
 import { CustomFieldBuilder } from "@kitejs-cms/dashboard-core/components/custom-field-builder";
 import { type GalleryPluginSettingsModel } from "../../../plugin-gallery-api";
 
@@ -53,7 +53,12 @@ export function GalleryFieldsSettings() {
   };
 
   if (isLoading) {
-    return <div>{t("common.loading")}</div>;
+    return (
+      <div className="space-y-6">
+        <Skeleton className="h-40 w-full" />
+        <Skeleton className="h-10 w-24 ml-auto" />
+      </div>
+    );
   }
 
   return (


### PR DESCRIPTION
## Summary
- display consents card skeleton while settings load
- expand user profile to full width when consents disabled