### PR TITLE
refactor: use settings context for plugin settings

### DIFF
--- a/packages/dashboard-core/src/context/settings-context.tsx
+++ b/packages/dashboard-core/src/context/settings-context.tsx
@@ -1,6 +1,7 @@
 import { useNavigate } from "react-router-dom";
 import { useApi } from "../hooks/use-api";
 import { CmsSettingsModel } from "@kitejs-cms/core/index";
+import type { PluginResponseModel } from "@kitejs-cms/core/modules/plugins/models/plugin-response.model";
 import { SettingsModel } from "../models/settings.model";
 import React, {
   createContext,
@@ -15,19 +16,23 @@ interface SettingsContextType {
   settingsSection: SettingsModel[];
   getSetting: <T = unknown>(
     namespace: string,
-    key: string
+    key: string,
   ) => Promise<T | null>;
   updateSetting: <T = unknown>(
     namespace: string,
     key: string,
-    value: T
+    value: T,
   ) => Promise<T | null>;
   hasUnsavedChanges: boolean;
   setHasUnsavedChanges: (value: boolean) => void;
+  plugins: PluginResponseModel[];
+  pluginsLoading: boolean;
+  fetchPlugins: () => Promise<void>;
+  disablePlugin: (namespace: string) => Promise<boolean>;
 }
 
 const SettingsContext = createContext<SettingsContextType | undefined>(
-  undefined
+  undefined,
 );
 
 export function SettingsProvider({
@@ -39,6 +44,8 @@ export function SettingsProvider({
 }) {
   const [cmsSettings, setCmsSettings] = useState<CmsSettingsModel | null>(null);
   const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
+  const [plugins, setPlugins] = useState<PluginResponseModel[]>([]);
+  const [pluginsLoading, setPluginsLoading] = useState(false);
   const { fetchData } = useApi();
   const navigate = useNavigate();
 
@@ -47,14 +54,14 @@ export function SettingsProvider({
       const { data } = await fetchData(`settings/${namespace}/${key}`, "GET");
       return data as T | null;
     },
-    [fetchData]
+    [fetchData],
   );
 
   const updateSetting = useCallback(
     async <T = unknown,>(
       namespace: string,
       key: string,
-      value: T
+      value: T,
     ): Promise<T | null> => {
       const { data } = await fetchData(`settings/${namespace}/${key}`, "PUT", {
         value,
@@ -69,14 +76,33 @@ export function SettingsProvider({
       }
       return data as T | null;
     },
-    [fetchData]
+    [fetchData],
+  );
+
+  const fetchPlugins = useCallback(async () => {
+    setPluginsLoading(true);
+    const { data } = await fetchData("plugins", "GET");
+    setPlugins((data as PluginResponseModel[]) ?? []);
+    setPluginsLoading(false);
+  }, [fetchData]);
+
+  const disablePlugin = useCallback(
+    async (namespace: string) => {
+      const { error } = await fetchData(`plugins/${namespace}/disable`, "POST");
+      if (!error) {
+        await fetchPlugins();
+        return true;
+      }
+      return false;
+    },
+    [fetchData, fetchPlugins],
   );
 
   useEffect(() => {
     (async () => {
       const data = await getSetting<{ value: CmsSettingsModel }>(
         "core",
-        "core:cms"
+        "core:cms",
       );
 
       if (!data) navigate("/init-cms");
@@ -93,6 +119,10 @@ export function SettingsProvider({
         settingsSection,
         hasUnsavedChanges,
         setHasUnsavedChanges,
+        plugins,
+        pluginsLoading,
+        fetchPlugins,
+        disablePlugin,
       }}
     >
       {children}
@@ -104,7 +134,7 @@ export function useSettingsContext() {
   const context = useContext(SettingsContext);
   if (!context) {
     throw new Error(
-      "useSettingsContext must be used within a SettingsProvider"
+      "useSettingsContext must be used within a SettingsProvider",
     );
   }
   return context;

--- a/packages/dashboard-core/src/modules/plugins/components/plugins-settings.tsx
+++ b/packages/dashboard-core/src/modules/plugins/components/plugins-settings.tsx
@@ -16,33 +16,26 @@ import {
   TooltipTrigger,
 } from "../../../components/ui/tooltip";
 import { Skeleton } from "../../../components/ui/skeleton";
-import { useApi } from "../../../hooks/use-api";
+import { useSettingsContext } from "../../../context/settings-context";
 import type { PluginResponseModel } from "@kitejs-cms/core/modules/plugins/models/plugin-response.model";
 
 export function PluginsSettings() {
   const { t } = useTranslation("plugins");
   const {
-    data: plugins,
-    loading,
-    fetchData: fetchPlugins,
-  } = useApi<PluginResponseModel[]>();
-  const { fetchData: disablePlugin } = useApi<{
-    success: boolean;
-    restartRequired: boolean;
-  }>();
+    plugins,
+    pluginsLoading: loading,
+    fetchPlugins,
+    disablePlugin,
+  } = useSettingsContext();
 
   useEffect(() => {
-    fetchPlugins("plugins");
+    fetchPlugins();
   }, [fetchPlugins]);
 
   const handleDisable = async (namespace: string) => {
-    const { error } = await disablePlugin(
-      `plugins/${namespace}/disable`,
-      "POST"
-    );
-    if (!error) {
+    const success = await disablePlugin(namespace);
+    if (success) {
       toast.warning(t("settings.toast.disabled"));
-      fetchPlugins("plugins");
     } else {
       toast.error(t("settings.toast.error"));
     }
@@ -50,7 +43,7 @@ export function PluginsSettings() {
 
   const getStatusLabel = (
     status: PluginResponseModel["status"],
-    enabled?: boolean
+    enabled?: boolean,
   ) => {
     if (!enabled) {
       return t("settings.status.disabled", "Disabled");
@@ -132,7 +125,7 @@ export function PluginsSettings() {
                       <span
                         aria-label={getStatusLabel(
                           plugin.status,
-                          plugin.enabled
+                          plugin.enabled,
                         )}
                         title={getStatusLabel(plugin.status, plugin.enabled)}
                         className={`inline-block h-3 w-3 rounded-full ${


### PR DESCRIPTION
## Summary
- extend settings context to manage plugins
- refactor plugin settings component to use context instead of direct API calls

## Testing
- `pnpm lint` *(fails: Cannot find module '@kitejs-cms/core' in plugin-gallery-api build)*
- `pnpm check-types` *(fails: Cannot find module '@kitejs-cms/core' in plugin-gallery-api build)*

------
https://chatgpt.com/codex/tasks/task_e_68bd5acfd8148328904d435e56b839ed