### PR TITLE
feat(analytics): add overview stats and world map

### DIFF
--- a/packages/plugin-analytics-api/src/analytics/analytics.controller.ts
+++ b/packages/plugin-analytics-api/src/analytics/analytics.controller.ts
@@ -17,6 +17,7 @@ import { AnalyticsEventResponseDto } from "./dto/analytics-event-response.dto";
 import { AnalyticsSummaryResponseDto } from "./dto/analytics-summary-response.dto";
 import { AnalyticsAggregateResponseDto } from "./dto/analytics-aggregate-response.dto";
 import { AnalyticsTechnologiesResponseDto } from "./dto/analytics-technologies-response.dto";
+import { AnalyticsLocationsResponseDto } from "./dto/analytics-locations-response.dto";
 import { AnalyticsApiKeyGuard } from "./guards/api-key.guard";
 import {
   JwtAuthGuard,
@@ -233,5 +234,44 @@ export class AnalyticsController {
     }
     const result = await this.analyticsService.getTechnologies(typedFilter);
     return new AnalyticsTechnologiesResponseDto(result);
+  }
+
+  @Get("events/locations")
+  @UseGuards(JwtAuthGuard, PermissionsGuard)
+  @Permissions(`${ANALYTICS_PLUGIN_NAMESPACE}:events.read`)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: "Retrieve analytics locations" })
+  @ApiResponse({
+    status: 200,
+    description: "Aggregated locations data",
+    type: AnalyticsLocationsResponseDto,
+  })
+  @ApiQuery({ name: "type", required: false, type: String })
+  @ApiQuery({ name: "identifier", required: false, type: String })
+  @ApiQuery({ name: "startDate", required: false, type: String })
+  @ApiQuery({ name: "endDate", required: false, type: String })
+  @ApiQuery({ name: "country", required: false, type: String })
+  async getLocations(@Query() query: Record<string, string>) {
+    const { filter } = parseQuery(query, {
+      allowedFilters: ["type", "identifier", "startDate", "endDate"],
+    });
+
+    delete filter.startDate;
+    delete filter.endDate;
+
+    const typedFilter = filter as {
+      type?: string;
+      identifier?: string;
+      createdAt?: Record<string, Date>;
+      country?: string;
+    };
+    const { startDate, endDate, country } = query;
+    if (startDate || endDate) {
+      typedFilter.createdAt = {};
+      if (startDate) typedFilter.createdAt.$gte = new Date(startDate);
+      if (endDate) typedFilter.createdAt.$lte = new Date(endDate);
+    }
+    const result = await this.analyticsService.getLocations(typedFilter, country);
+    return new AnalyticsLocationsResponseDto(result);
   }
 }

--- a/packages/plugin-analytics-api/src/analytics/dto/analytics-locations-response.dto.ts
+++ b/packages/plugin-analytics-api/src/analytics/dto/analytics-locations-response.dto.ts
@@ -1,0 +1,16 @@
+import { ApiProperty } from "@nestjs/swagger";
+import type { AnalyticsLocationsResponseModel } from "../models/analytics-locations-response.model";
+
+export class AnalyticsLocationsResponseDto
+  implements AnalyticsLocationsResponseModel
+{
+  @ApiProperty({ type: Object, required: false })
+  countries?: Record<string, number>;
+
+  @ApiProperty({ type: Object, required: false })
+  cities?: Record<string, number>;
+
+  constructor(partial: Partial<AnalyticsLocationsResponseDto>) {
+    Object.assign(this, partial);
+  }
+}

--- a/packages/plugin-analytics-api/src/analytics/dto/analytics-summary-response.dto.ts
+++ b/packages/plugin-analytics-api/src/analytics/dto/analytics-summary-response.dto.ts
@@ -10,6 +10,9 @@ export class AnalyticsSummaryResponseDto
   @ApiProperty()
   uniqueVisitors!: number;
 
+  @ApiProperty()
+  newUsers!: number;
+
   @ApiProperty({ type: Object })
   eventsByType!: Record<string, number>;
 

--- a/packages/plugin-analytics-api/src/analytics/index.ts
+++ b/packages/plugin-analytics-api/src/analytics/index.ts
@@ -12,5 +12,6 @@ export * from "./models/analytics-plugin-settings.model";
 export * from "./models/track-event.model";
 export * from "./models/analytics-event-response.model";
 export * from "./models/analytics-summary-response.model";
+export * from "./models/analytics-locations-response.model";
 export * from "./models/analytics-aggregate-response.model";
 export * from "./models/analytics-technologies-response.model";

--- a/packages/plugin-analytics-api/src/analytics/models/analytics-locations-response.model.ts
+++ b/packages/plugin-analytics-api/src/analytics/models/analytics-locations-response.model.ts
@@ -1,0 +1,4 @@
+export interface AnalyticsLocationsResponseModel {
+  countries?: Record<string, number>;
+  cities?: Record<string, number>;
+}

--- a/packages/plugin-analytics-api/src/analytics/models/analytics-summary-response.model.ts
+++ b/packages/plugin-analytics-api/src/analytics/models/analytics-summary-response.model.ts
@@ -1,5 +1,6 @@
 export type AnalyticsSummaryResponseModel = {
   totalEvents: number;
   uniqueVisitors: number;
+  newUsers: number;
   eventsByType: Record<string, number>;
 };

--- a/packages/plugin-analytics-dashboard/src/locales/en.json
+++ b/packages/plugin-analytics-dashboard/src/locales/en.json
@@ -14,7 +14,11 @@
   "summary": {
     "title": "Summary",
     "totalEvents": "Total events",
-    "uniqueVisitors": "Unique visitors"
+    "uniqueVisitors": "Unique visitors",
+    "activeUsers": "Active users",
+    "newUsers": "New users",
+    "locations": "Locations",
+    "cities": "Cities"
   },
   "events": {
     "title": "Events",

--- a/packages/plugin-analytics-dashboard/src/locales/it.json
+++ b/packages/plugin-analytics-dashboard/src/locales/it.json
@@ -14,7 +14,11 @@
   "summary": {
     "title": "Riepilogo",
     "totalEvents": "Eventi totali",
-    "uniqueVisitors": "Visitatori unici"
+    "uniqueVisitors": "Visitatori unici",
+    "activeUsers": "Utenti attivi",
+    "newUsers": "Nuovi utenti",
+    "locations": "Provenienza",
+    "cities": "Città"
   },
   "events": {
     "title": "Eventi",

--- a/packages/plugin-analytics-dashboard/src/pages/analytics-overview.tsx
+++ b/packages/plugin-analytics-dashboard/src/pages/analytics-overview.tsx
@@ -1,5 +1,6 @@
-import { useEffect } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
+import type { DateRange } from "react-day-picker";
 import {
   Card,
   CardHeader,
@@ -9,39 +10,220 @@ import {
   useBreadcrumb,
   useHasPermission,
 } from "@kitejs-cms/dashboard-core";
-import type { AnalyticsSummaryResponseModel } from "@kitejs-cms/plugin-analytics-api";
+import type {
+  AnalyticsSummaryResponseModel,
+  AnalyticsLocationsResponseModel,
+} from "@kitejs-cms/plugin-analytics-api";
+import { DatePicker } from "../components/date-picker";
+import {
+  ResponsiveContainer,
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  Tooltip as RechartsTooltip,
+} from "recharts";
+const geoUrl =
+  "https://unpkg.com/world-atlas@2.0.2/countries-110m.json";
+
+interface GeoFeature {
+  rsmKey: string;
+  properties: { ISO_A2: string };
+}
 
 export function AnalyticsOverviewPage() {
   const { t } = useTranslation("analytics");
   const { setBreadcrumb } = useBreadcrumb();
   const hasPermission = useHasPermission();
-  const { data: summary, fetchData: fetchSummary } =
-    useApi<AnalyticsSummaryResponseModel>();
+
+  const { fetchData: fetchSummary } = useApi<AnalyticsSummaryResponseModel>();
+  const {
+    data: locations,
+    fetchData: fetchLocations,
+  } = useApi<AnalyticsLocationsResponseModel>();
+
+  const [summary, setSummary] =
+    useState<AnalyticsSummaryResponseModel | null>(null);
+  const [range, setRange] = useState<DateRange | undefined>(() => ({
+    from: new Date(Date.now() - 6 * 24 * 60 * 60 * 1000),
+    to: new Date(),
+  }));
+  const [chartData, setChartData] = useState<
+    { date: string; active: number; new: number }[]
+  >([]);
+  const [selectedCountry, setSelectedCountry] = useState<string | null>(null);
+  const [mapComponents, setMapComponents] = useState<{
+    ComposableMap: React.ComponentType<Record<string, unknown>>;
+    Geographies: React.ComponentType<Record<string, unknown>>;
+    Geography: React.ComponentType<Record<string, unknown>>;
+  } | null>(null);
 
   useEffect(() => {
     setBreadcrumb([
       { label: t("breadcrumb.home"), path: "/" },
       { label: t("breadcrumb.analytics"), path: "/analytics" },
     ]);
-    if (hasPermission("analytics:summary.read")) {
-      fetchSummary("analytics/events/summary");
-    }
-  }, [setBreadcrumb, t, fetchSummary, hasPermission]);
+  }, [setBreadcrumb, t]);
+
+  const loadSummary = useCallback(async () => {
+    if (!range?.from || !range?.to || !hasPermission("analytics:summary.read"))
+      return;
+    const start = range.from.toISOString().slice(0, 10);
+    const end = range.to.toISOString().slice(0, 10);
+    const { data } = await fetchSummary(
+      `analytics/events/summary?startDate=${start}&endDate=${end}`
+    );
+    if (data) setSummary(data);
+
+    const days =
+      Math.floor((range.to.getTime() - range.from.getTime()) / 86400000) + 1;
+    // eslint-disable-next-line turbo/no-undeclared-env-vars
+    const baseUrl = import.meta.env.VITE_API_URL;
+    const promises = Array.from({ length: days }).map((_, i) => {
+      const d = new Date(range.from!.getTime() + i * 86400000);
+      const ds = d.toISOString().slice(0, 10);
+      return fetch(`${baseUrl}/analytics/events/summary?startDate=${ds}&endDate=${ds}`, {
+        credentials: "include",
+      })
+        .then((r) => r.json())
+        .then((res) => ({
+          date: ds,
+          active: res.data?.uniqueVisitors ?? 0,
+          new: res.data?.newUsers ?? 0,
+        }));
+    });
+    const results = await Promise.all(promises);
+    setChartData(results);
+  }, [range, fetchSummary, hasPermission]);
+
+  const loadLocations = useCallback(() => {
+    if (!range?.from || !range?.to || !hasPermission("analytics:events.read"))
+      return;
+    const params = new URLSearchParams({
+      startDate: range.from.toISOString().slice(0, 10),
+      endDate: range.to.toISOString().slice(0, 10),
+    });
+    if (selectedCountry) params.set("country", selectedCountry);
+    fetchLocations(`analytics/events/locations?${params.toString()}`);
+  }, [range, fetchLocations, selectedCountry, hasPermission]);
+
+  useEffect(() => {
+    loadSummary();
+  }, [loadSummary]);
+
+  useEffect(() => {
+    loadLocations();
+  }, [loadLocations]);
+
+  useEffect(() => {
+    import("https://cdn.skypack.dev/react-simple-maps@3?min").then((mod) => {
+      setMapComponents(
+        mod as {
+          ComposableMap: React.ComponentType<Record<string, unknown>>;
+          Geographies: React.ComponentType<Record<string, unknown>>;
+          Geography: React.ComponentType<Record<string, unknown>>;
+        }
+      );
+    });
+  }, []);
+
+  const maxCountry = Math.max(
+    ...Object.values(locations?.countries ?? { none: 0 })
+  );
 
   return (
     <div className="space-y-4 p-4">
+      <DatePicker value={range} onValueChange={setRange} />
+
       {hasPermission("analytics:summary.read") && (
         <Card>
           <CardHeader>
             <CardTitle>{t("summary.title")}</CardTitle>
           </CardHeader>
+          <CardContent>
+            <div className="flex gap-4 mb-4">
+              <div>
+                {t("summary.activeUsers")}: {summary?.uniqueVisitors ?? "-"}
+              </div>
+              <div>
+                {t("summary.newUsers")}: {summary?.newUsers ?? "-"}
+              </div>
+            </div>
+            <div className="h-64">
+              <ResponsiveContainer width="100%" height="100%">
+                <LineChart data={chartData}>
+                  <XAxis dataKey="date" />
+                  <YAxis />
+                  <RechartsTooltip />
+                  <Line
+                    type="monotone"
+                    dataKey="active"
+                    stroke="var(--chart-1)"
+                    name={t("summary.activeUsers")}
+                  />
+                  <Line
+                    type="monotone"
+                    dataKey="new"
+                    stroke="var(--chart-2)"
+                    name={t("summary.newUsers")}
+                  />
+                </LineChart>
+              </ResponsiveContainer>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {hasPermission("analytics:events.read") && (
+        <Card>
+          <CardHeader>
+            <CardTitle>{t("summary.locations")}</CardTitle>
+          </CardHeader>
           <CardContent className="flex gap-4">
-            <div>
-              {t("summary.totalEvents")}: {summary?.totalEvents ?? "-"}
+            <div className="flex-1 h-80">
+              {mapComponents && (
+                <mapComponents.ComposableMap projectionConfig={{ scale: 150 }}>
+                  <mapComponents.Geographies geography={geoUrl}>
+                    {({ geographies }: { geographies: GeoFeature[] }) =>
+                      geographies.map((geo) => {
+                        const iso = geo.properties.ISO_A2;
+                        const val = locations?.countries?.[iso] ?? 0;
+                        const fill = val
+                          ? `rgba(37,99,235,${0.2 + (val / maxCountry) * 0.8})`
+                          : "#EEE";
+                        return (
+                          <mapComponents.Geography
+                            key={geo.rsmKey}
+                            geography={geo as unknown as Record<string, unknown>}
+                            onClick={() => {
+                              setSelectedCountry(iso);
+                            }}
+                            style={{
+                              default: { fill, outline: "none" },
+                              hover: { fill: "#999", outline: "none" },
+                              pressed: { fill: "#666", outline: "none" },
+                            }}
+                          />
+                        );
+                      })
+                    }
+                  </mapComponents.Geographies>
+                </mapComponents.ComposableMap>
+              )}
             </div>
-            <div>
-              {t("summary.uniqueVisitors")}: {summary?.uniqueVisitors ?? "-"}
-            </div>
+            {selectedCountry && locations?.cities && (
+              <div className="w-64 overflow-y-auto">
+                <h4 className="font-semibold mb-2">{t("summary.cities")}</h4>
+                <ul className="space-y-1">
+                  {Object.entries(locations.cities).map(([city, count]) => (
+                    <li key={city} className="flex justify-between">
+                      <span>{city}</span>
+                      <span>{count}</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
           </CardContent>
         </Card>
       )}


### PR DESCRIPTION
## Summary
- display active and new users trend with selectable range on analytics overview page
- add interactive world map showing event origins and city breakdown
- expose locations API and include new user counts in analytics summary

## Testing
- `pnpm install` *(fails: ERR_PNPM_FETCH_403)*
- `pnpm --filter @kitejs-cms/plugin-analytics-dashboard lint`
- `pnpm --filter @kitejs-cms/plugin-analytics-api lint` *(fails: Cannot find package '@kitejs-cms/eslint-config')*
- `pnpm --filter @kitejs-cms/plugin-analytics-dashboard check-types` *(fails: TS errors due to missing deps)*

------
https://chatgpt.com/codex/tasks/task_e_68c48e2f95b48328b4d9e700a184b4a6