### PR TITLE
feat: add traffic sources chart

### DIFF
--- a/packages/plugin-analytics-api/src/analytics/analytics.controller.ts
+++ b/packages/plugin-analytics-api/src/analytics/analytics.controller.ts
@@ -61,7 +61,7 @@ export class AnalyticsController {
 
     const referrerHeader =
       (req.headers.referer as string) || (req.headers.referrer as string);
-    let referrer = dto.referrer;
+    let referrer = dto.referrer || dto.payload?.referrer;
     if (referrerHeader) {
       try {
         referrer = new URL(referrerHeader).hostname.replace(/^www\./, "");
@@ -71,11 +71,15 @@ export class AnalyticsController {
     }
     if (!referrer) referrer = "direct";
 
+    const payload = dto.payload ? { ...dto.payload } : undefined;
+    if (payload) delete payload.referrer;
+
     const event: TrackEvent = {
       ...dto,
+      payload,
       userAgent,
       origin: (req.headers.origin as string) || dto.origin,
-       referrer,
+      referrer,
       ip,
       geo,
       fingerprint,

--- a/packages/plugin-analytics-api/src/analytics/analytics.controller.ts
+++ b/packages/plugin-analytics-api/src/analytics/analytics.controller.ts
@@ -5,6 +5,7 @@ import { AnalyticsSummaryResponseDto } from "./dto/analytics-summary-response.dt
 import { AnalyticsAggregateResponseDto } from "./dto/analytics-aggregate-response.dto";
 import { AnalyticsTechnologiesResponseDto } from "./dto/analytics-technologies-response.dto";
 import { AnalyticsLocationsResponseDto } from "./dto/analytics-locations-response.dto";
+import { AnalyticsSourcesResponseDto } from "./dto/analytics-sources-response.dto";
 import { AnalyticsApiKeyGuard } from "./guards/api-key.guard";
 import type { Request } from "express";
 import geoip from "geoip-lite";
@@ -58,10 +59,23 @@ export class AnalyticsController {
         ? createHash("sha256").update(`${ip}-${userAgent}`).digest("hex")
         : undefined;
 
+    const referrerHeader =
+      (req.headers.referer as string) || (req.headers.referrer as string);
+    let referrer = dto.referrer;
+    if (referrerHeader) {
+      try {
+        referrer = new URL(referrerHeader).hostname.replace(/^www\./, "");
+      } catch {
+        referrer = referrerHeader;
+      }
+    }
+    if (!referrer) referrer = "direct";
+
     const event: TrackEvent = {
       ...dto,
       userAgent,
       origin: (req.headers.origin as string) || dto.origin,
+       referrer,
       ip,
       geo,
       fingerprint,
@@ -277,5 +291,42 @@ export class AnalyticsController {
       country
     );
     return new AnalyticsLocationsResponseDto(result);
+  }
+
+  @Get("events/sources")
+  @UseGuards(JwtAuthGuard, PermissionsGuard)
+  @Permissions(`${ANALYTICS_PLUGIN_NAMESPACE}:events.read`)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: "Retrieve analytics traffic sources" })
+  @ApiResponse({
+    status: 200,
+    description: "Aggregated sources data",
+    type: AnalyticsSourcesResponseDto,
+  })
+  @ApiQuery({ name: "type", required: false, type: String })
+  @ApiQuery({ name: "identifier", required: false, type: String })
+  @ApiQuery({ name: "startDate", required: false, type: String })
+  @ApiQuery({ name: "endDate", required: false, type: String })
+  async getSources(@Query() query: Record<string, string>) {
+    const { filter } = parseQuery(query, {
+      allowedFilters: ["type", "identifier", "startDate", "endDate"],
+    });
+
+    delete filter.startDate;
+    delete filter.endDate;
+
+    const typedFilter = filter as {
+      type?: string;
+      identifier?: string;
+      createdAt?: Record<string, Date>;
+    };
+    const { startDate, endDate } = query;
+    if (startDate || endDate) {
+      typedFilter.createdAt = {};
+      if (startDate) typedFilter.createdAt.$gte = new Date(startDate);
+      if (endDate) typedFilter.createdAt.$lte = new Date(endDate);
+    }
+    const result = await this.analyticsService.getSources(typedFilter);
+    return new AnalyticsSourcesResponseDto(result);
   }
 }

--- a/packages/plugin-analytics-api/src/analytics/dto/analytics-event-response.dto.ts
+++ b/packages/plugin-analytics-api/src/analytics/dto/analytics-event-response.dto.ts
@@ -24,6 +24,9 @@ export class AnalyticsEventResponseDto implements AnalyticsEventResponseModel {
   identifier?: string;
 
   @ApiProperty({ required: false })
+  referrer?: string;
+
+  @ApiProperty({ required: false })
   duration?: number;
 
   @ApiProperty({ required: false })

--- a/packages/plugin-analytics-api/src/analytics/dto/analytics-sources-response.dto.ts
+++ b/packages/plugin-analytics-api/src/analytics/dto/analytics-sources-response.dto.ts
@@ -1,0 +1,11 @@
+import { ApiProperty } from "@nestjs/swagger";
+import type { AnalyticsSourcesResponseModel } from "../models/analytics-sources-response.model";
+
+export class AnalyticsSourcesResponseDto implements AnalyticsSourcesResponseModel {
+  @ApiProperty({ type: Object })
+  sources!: Record<string, number>;
+
+  constructor(partial: Partial<AnalyticsSourcesResponseDto>) {
+    Object.assign(this, partial);
+  }
+}

--- a/packages/plugin-analytics-api/src/analytics/dto/track-event.dto.ts
+++ b/packages/plugin-analytics-api/src/analytics/dto/track-event.dto.ts
@@ -29,6 +29,11 @@ export class TrackEventDto implements TrackEventModel {
 
   @ApiProperty({ required: false })
   @IsOptional()
+  @IsString()
+  referrer?: string;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
   @IsNumber()
   duration?: number;
 }

--- a/packages/plugin-analytics-api/src/analytics/index.ts
+++ b/packages/plugin-analytics-api/src/analytics/index.ts
@@ -15,3 +15,4 @@ export * from "./models/analytics-summary-response.model";
 export * from "./models/analytics-locations-response.model";
 export * from "./models/analytics-aggregate-response.model";
 export * from "./models/analytics-technologies-response.model";
+export * from "./models/analytics-sources-response.model";

--- a/packages/plugin-analytics-api/src/analytics/models/analytics-event-response.model.ts
+++ b/packages/plugin-analytics-api/src/analytics/models/analytics-event-response.model.ts
@@ -5,6 +5,7 @@ export type AnalyticsEventResponseModel = {
   userAgent?: string;
   origin?: string;
   identifier?: string;
+  referrer?: string;
   duration?: number;
   ip?: string;
   geo?: Record<string, any>;

--- a/packages/plugin-analytics-api/src/analytics/models/analytics-sources-response.model.ts
+++ b/packages/plugin-analytics-api/src/analytics/models/analytics-sources-response.model.ts
@@ -1,0 +1,3 @@
+export type AnalyticsSourcesResponseModel = {
+  sources: Record<string, number>;
+};

--- a/packages/plugin-analytics-api/src/analytics/models/track-event.model.ts
+++ b/packages/plugin-analytics-api/src/analytics/models/track-event.model.ts
@@ -3,5 +3,6 @@ export type TrackEventModel = {
   payload?: Record<string, any>;
   origin?: string;
   identifier?: string;
+  referrer?: string;
   duration?: number;
 };

--- a/packages/plugin-analytics-api/src/analytics/schemas/analytics-event.schema.ts
+++ b/packages/plugin-analytics-api/src/analytics/schemas/analytics-event.schema.ts
@@ -23,6 +23,9 @@ export class AnalyticsEvent extends Document {
   @Prop({ type: String })
   identifier?: string;
 
+  @Prop({ type: String })
+  referrer?: string;
+
   @Prop({ type: Number })
   duration?: number;
 

--- a/packages/plugin-analytics-dashboard/src/locales/en.json
+++ b/packages/plugin-analytics-dashboard/src/locales/en.json
@@ -22,7 +22,9 @@
     "city": "City",
     "visitors": "Visitors",
     "noCityData": "No data",
-    "world": "World"
+    "world": "World",
+    "sources": "Traffic sources",
+    "noSourceData": "No data"
   },
   "events": {
     "title": "Events",

--- a/packages/plugin-analytics-dashboard/src/locales/it.json
+++ b/packages/plugin-analytics-dashboard/src/locales/it.json
@@ -22,7 +22,9 @@
     "city": "Città",
     "visitors": "Visitatori",
     "noCityData": "Nessun dato",
-    "world": "Mondo"
+    "world": "Mondo",
+    "sources": "Origini traffico",
+    "noSourceData": "Nessun dato"
   },
   "events": {
     "title": "Eventi",

--- a/packages/plugin-analytics-dashboard/src/pages/analytics-overview.tsx
+++ b/packages/plugin-analytics-dashboard/src/pages/analytics-overview.tsx
@@ -75,7 +75,7 @@ export function AnalyticsOverviewPage() {
     null
   );
   const [range, setRange] = useState<DateRange | undefined>(() => ({
-    from: new Date(Date.now() - 6 * 24 * 60 * 60 * 1000),
+    from: new Date(Date.now() - 29 * 24 * 60 * 60 * 1000),
     to: new Date(),
   }));
   const [chartData, setChartData] = useState<
@@ -176,7 +176,11 @@ export function AnalyticsOverviewPage() {
 
       <div className="grid gap-6 md:grid-cols-3">
         {hasPermission("analytics:summary.read") && (
-          <Card className="shadow-neutral-50 gap-0 py-0 md:col-span-3 rounded-2xl overflow-hidden">
+          <Card
+            className={`shadow-neutral-50 gap-0 py-0 rounded-2xl overflow-hidden ${
+              hasPermission("analytics:events.read") ? "md:col-span-2" : "md:col-span-3"
+            }`}
+          >
             <CardHeader className="bg-secondary text-primary py-4 rounded-t-xl flex flex-row items-center justify-between space-y-0">
               <CardTitle>{t("summary.title")}</CardTitle>
               <Button
@@ -283,7 +287,7 @@ export function AnalyticsOverviewPage() {
 
         {hasPermission("analytics:events.read") && (
           <>
-            <Card className="shadow-neutral-50 gap-0 py-0 md:col-span-3 rounded-2xl overflow-hidden">
+            <Card className="shadow-neutral-50 gap-0 py-0 md:col-span-1 rounded-2xl overflow-hidden">
               <CardHeader className="bg-secondary text-primary py-4 rounded-t-xl flex flex-row items-center justify-between space-y-0">
                 <CardTitle>{t("summary.sources")}</CardTitle>
                 <Button


### PR DESCRIPTION
## Summary
- track and persist event referrer information
- expose new analytics events sources API
- display traffic sources pie chart on analytics overview page