### PR TITLE
feat(analytics): add dashboard widget

### DIFF
--- a/packages/plugin-analytics-dashboard/src/components/analytics-dashboard-widget.tsx
+++ b/packages/plugin-analytics-dashboard/src/components/analytics-dashboard-widget.tsx
@@ -1,0 +1,99 @@
+import { useEffect } from "react";
+import { useTranslation } from "react-i18next";
+import { BarChart3 } from "lucide-react";
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardContent,
+  useApi,
+} from "@kitejs-cms/dashboard-core";
+import { useNavigate } from "react-router-dom";
+
+interface AnalyticsSummary {
+  totalEvents: number;
+  uniqueVisitors: number;
+  newUsers: number;
+}
+
+function formatNumber(n: number, locale: string) {
+  return new Intl.NumberFormat(locale).format(n);
+}
+
+export function AnalyticsDashboardWidget() {
+  const navigate = useNavigate();
+  const { t, i18n } = useTranslation("analytics");
+  const { data, fetchData } = useApi<AnalyticsSummary>();
+
+  useEffect(() => {
+    const end = new Date();
+    const start = new Date();
+    start.setDate(end.getDate() - 29);
+    const startStr = start.toISOString().slice(0, 10);
+    const endStr = end.toISOString().slice(0, 10);
+    fetchData(`analytics/events/summary?startDate=${startStr}&endDate=${endStr}`);
+  }, [fetchData]);
+
+  const summary: AnalyticsSummary =
+    data ?? { totalEvents: 0, uniqueVisitors: 0, newUsers: 0 };
+
+  const goAnalytics = () => navigate("/analytics");
+
+  return (
+    <Card className="h-full flex flex-col">
+      <CardHeader className="flex items-start justify-between gap-1.5">
+        <div className="flex items-center gap-2">
+          <div className="p-3 rounded-lg bg-gradient-to-r from-blue-400 to-blue-600 text-white">
+            <BarChart3 className="h-6 w-6" />
+          </div>
+          <div className="flex flex-col pl-2">
+            <CardTitle
+              role="button"
+              onClick={goAnalytics}
+              className="text-sm font-semibold hover:underline cursor-pointer"
+              title={t("dashboardWidget.viewDetails")}
+            >
+              {t("dashboardWidget.title")}
+            </CardTitle>
+            <span className="text-[11px] text-muted-foreground">
+              {t("dashboardWidget.last30Days")}
+            </span>
+          </div>
+        </div>
+        <div className="text-right">
+          <button
+            onClick={goAnalytics}
+            className="text-2xl md:text-3xl font-bold leading-tight hover:underline cursor-pointer"
+            aria-label={t("dashboardWidget.viewDetails")}
+            title={t("dashboardWidget.viewDetails")}
+          >
+            {formatNumber(summary.totalEvents, i18n.language)}
+          </button>
+          <p className="text-[11px] text-muted-foreground">
+            {t("dashboardWidget.totalEvents")}
+          </p>
+        </div>
+      </CardHeader>
+      <CardContent className="grid grid-cols-2 gap-4 pt-0">
+        <div className="text-center">
+          <p className="text-[11px] text-muted-foreground">
+            {t("dashboardWidget.uniqueVisitors")}
+          </p>
+          <p className="text-base font-semibold">
+            {formatNumber(summary.uniqueVisitors, i18n.language)}
+          </p>
+        </div>
+        <div className="text-center">
+          <p className="text-[11px] text-muted-foreground">
+            {t("dashboardWidget.newUsers")}
+          </p>
+          <p className="text-base font-semibold">
+            {formatNumber(summary.newUsers, i18n.language)}
+          </p>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+export default AnalyticsDashboardWidget;

--- a/packages/plugin-analytics-dashboard/src/locales/en.json
+++ b/packages/plugin-analytics-dashboard/src/locales/en.json
@@ -49,5 +49,13 @@
     "downloadCsv": "Download CSV",
     "copyCsv": "Copy CSV",
     "selectedRange": "Last {{days}} days"
+  },
+  "dashboardWidget": {
+    "title": "Analytics",
+    "last30Days": "Last 30 days",
+    "totalEvents": "Total events",
+    "uniqueVisitors": "Unique visitors",
+    "newUsers": "New users",
+    "viewDetails": "View analytics"
   }
 }

--- a/packages/plugin-analytics-dashboard/src/locales/it.json
+++ b/packages/plugin-analytics-dashboard/src/locales/it.json
@@ -49,5 +49,13 @@
     "downloadCsv": "Scarica CSV",
     "copyCsv": "Copia CSV",
     "selectedRange": "Ultimi {{days}} giorni"
+  },
+  "dashboardWidget": {
+    "title": "Analytics",
+    "last30Days": "Ultimi 30 giorni",
+    "totalEvents": "Eventi totali",
+    "uniqueVisitors": "Visitatori unici",
+    "newUsers": "Nuovi utenti",
+    "viewDetails": "Vai a Analytics"
   }
 }

--- a/packages/plugin-analytics-dashboard/src/module.tsx
+++ b/packages/plugin-analytics-dashboard/src/module.tsx
@@ -3,6 +3,7 @@ import type { DashboardModule } from "@kitejs-cms/dashboard-core";
 import { AnalyticsOverviewPage } from "./pages/analytics-overview";
 import { AnalyticsEventsPage } from "./pages/analytics-events";
 import { AnalyticsTechnologiesPage } from "./pages/analytics-technologies";
+import { AnalyticsDashboardWidget } from "./components/analytics-dashboard-widget";
 
 export const ANALYTICS_PLUGIN_NAMESPACE = "analytics";
 export const ANALYTICS_SETTINGS_KEY = `${ANALYTICS_PLUGIN_NAMESPACE}:config`;
@@ -60,4 +61,14 @@ export const AnalyticsModule: DashboardModule = {
       },
     ],
   },
+  dashboardWidgets: [
+    {
+      key: "analytics-dashboard",
+      component: <AnalyticsDashboardWidget />,
+      defaultWidth: 2,
+      defaultHeight: 1,
+      minWidth: 2,
+      minHeight: 1,
+    },
+  ],
 };


### PR DESCRIPTION
## Summary
- add Analytics dashboard widget showing 30-day summary
- register widget with analytics module and locales

## Testing
- `pnpm --filter @kitejs-cms/plugin-analytics-dashboard lint`
- `pnpm --filter @kitejs-cms/plugin-analytics-dashboard build` *(fails: TS2307 cannot find module '@kitejs-cms/typescript-config/react-library.json')*

------
https://chatgpt.com/codex/tasks/task_e_68c5e0371d548328bd5b8f689cb6cf42