### PR TITLE
feat(analytics-dashboard): add analytics plugin settings

### DIFF
--- a/packages/plugin-analytics-api/package.json
+++ b/packages/plugin-analytics-api/package.json
@@ -39,7 +39,8 @@
     "@nestjs/core": "^11.0.0",
     "@nestjs/platform-express": "^11.0.0",
     "@nestjs/swagger": "^11.0.0",
-    "@nestjs/mongoose": "^11.0.0"
+    "@nestjs/mongoose": "^11.0.0",
+    "@nestjs/schedule": "^5.0.0"
   },
   "dependencies": {
     "class-transformer": "^0.5.1",
@@ -59,6 +60,7 @@
     "@nestjs/platform-express": "^11.0.0",
     "@nestjs/swagger": "^11.0.0",
     "@nestjs/mongoose": "^11.0.0",
+    "@nestjs/schedule": "^5.0.0",
     "typescript": "^5.7.3",
     "@types/geoip-lite": "^1.4.4",
     "@types/ua-parser-js": "^0.7.39",

--- a/packages/plugin-analytics-api/src/analytics/analytics.module.ts
+++ b/packages/plugin-analytics-api/src/analytics/analytics.module.ts
@@ -1,5 +1,6 @@
 import { Module } from "@nestjs/common";
 import { MongooseModule } from "@nestjs/mongoose";
+import { ScheduleModule } from "@nestjs/schedule";
 import { SettingsModule, UsersModule } from "@kitejs-cms/core";
 import { AnalyticsController } from "./analytics.controller";
 import { AnalyticsService } from "./analytics.service";
@@ -16,6 +17,7 @@ import { AnalyticsApiKeyGuard } from "./guards/api-key.guard";
     ]),
     SettingsModule,
     UsersModule,
+    ScheduleModule.forRoot(),
   ],
   controllers: [AnalyticsController],
   providers: [AnalyticsService, AnalyticsApiKeyGuard],

--- a/packages/plugin-analytics-api/src/analytics/analytics.service.ts
+++ b/packages/plugin-analytics-api/src/analytics/analytics.service.ts
@@ -45,9 +45,16 @@ export class AnalyticsService {
         ANALYTICS_SETTINGS_KEY
       );
 
-    const retentionDays = value?.retentionDays ?? DEFAULT_RETENTION_DAYS;
-    const cutoff = new Date(Date.now() - retentionDays * 24 * 60 * 60 * 1000);
-    await this.eventModel.deleteMany({ createdAt: { $lt: cutoff } }).exec();
+    const retentionDays =
+      value?.retentionDays === undefined
+        ? DEFAULT_RETENTION_DAYS
+        : value.retentionDays;
+    if (retentionDays !== null) {
+      const cutoff = new Date(
+        Date.now() - retentionDays * 24 * 60 * 60 * 1000
+      );
+      await this.eventModel.deleteMany({ createdAt: { $lt: cutoff } }).exec();
+    }
   }
 
   async countEvents(

--- a/packages/plugin-analytics-api/src/analytics/analytics.service.ts
+++ b/packages/plugin-analytics-api/src/analytics/analytics.service.ts
@@ -1,5 +1,6 @@
 import { BadRequestException, Injectable } from "@nestjs/common";
 import { InjectModel } from "@nestjs/mongoose";
+import { Cron, CronExpression } from "@nestjs/schedule";
 import { Model } from "mongoose";
 import { TrackEvent } from "./dto/track-event.dto";
 import {
@@ -39,6 +40,10 @@ export class AnalyticsService {
     } else {
       await this.eventModel.create(dto);
     }
+  }
+
+  @Cron(CronExpression.EVERY_DAY_AT_MIDNIGHT)
+  async pruneOldEvents() {
     const { value } =
       await this.settingsService.findOne<AnalyticsPluginSettingsModel>(
         ANALYTICS_PLUGIN_NAMESPACE,

--- a/packages/plugin-analytics-api/src/analytics/models/analytics-plugin-settings.model.ts
+++ b/packages/plugin-analytics-api/src/analytics/models/analytics-plugin-settings.model.ts
@@ -1,7 +1,7 @@
 export type AnalyticsPluginSettingsModel = {
   apiKey: string;
   /** Number of days to retain analytics data before pruning */
-  retentionDays: number;
+  retentionDays: number | null;
   /** Optional mapping between event type keys and custom labels */
   eventTypeLabels?: Record<string, string>;
 };

--- a/packages/plugin-analytics-dashboard/src/components/analytics-settings.tsx
+++ b/packages/plugin-analytics-dashboard/src/components/analytics-settings.tsx
@@ -1,10 +1,12 @@
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { Eye, EyeOff } from "lucide-react";
 import {
   Button,
   Input,
   Label,
   Skeleton,
+  Switch,
   useSettingsContext,
 } from "@kitejs-cms/dashboard-core";
 import type { AnalyticsPluginSettingsModel } from "@kitejs-cms/plugin-analytics-api";
@@ -26,6 +28,7 @@ export function AnalyticsSettings() {
   const [settings, setSettings] =
     useState<AnalyticsPluginSettingsModel | null>(null);
   const [loading, setLoading] = useState(true);
+  const [showApiKey, setShowApiKey] = useState(false);
 
   useEffect(() => {
     const loadSettings = async () => {
@@ -48,7 +51,20 @@ export function AnalyticsSettings() {
 
   const handleRetentionChange = (val: string) => {
     setSettings((prev) =>
-      prev ? { ...prev, retentionDays: parseInt(val, 10) || 0 } : prev,
+      prev
+        ? {
+            ...prev,
+            retentionDays:
+              val.trim() === "" ? null : Number.parseInt(val, 10) || 0,
+          }
+        : prev,
+    );
+    setHasUnsavedChanges(true);
+  };
+
+  const toggleRetention = (checked: boolean) => {
+    setSettings((prev) =>
+      prev ? { ...prev, retentionDays: checked ? null : 0 } : prev,
     );
     setHasUnsavedChanges(true);
   };
@@ -92,7 +108,20 @@ export function AnalyticsSettings() {
       <div className="space-y-2">
         <Label htmlFor="apiKey">{t("settings.general.apiKey")}</Label>
         <div className="flex gap-2">
-          <Input id="apiKey" value={settings?.apiKey ?? ""} readOnly />
+          <Input
+            id="apiKey"
+            type={showApiKey ? "text" : "password"}
+            value={settings?.apiKey ?? ""}
+            readOnly
+          />
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => setShowApiKey((s) => !s)}
+            size="icon"
+          >
+            {showApiKey ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+          </Button>
           <Button type="button" variant="outline" onClick={regenerateApiKey}>
             {t("settings.general.regenerate")}
           </Button>
@@ -106,9 +135,20 @@ export function AnalyticsSettings() {
         <Input
           id="retentionDays"
           type="number"
-          value={settings?.retentionDays ?? 0}
+          value={settings?.retentionDays ?? ""}
           onChange={(e) => handleRetentionChange(e.target.value)}
+          disabled={settings?.retentionDays === null}
         />
+        <div className="flex items-center gap-2">
+          <Switch
+            id="noRetention"
+            checked={settings?.retentionDays === null}
+            onCheckedChange={toggleRetention}
+          />
+          <Label htmlFor="noRetention">
+            {t("settings.general.noRetention")}
+          </Label>
+        </div>
       </div>
 
       <div className="fixed bottom-4 right-4 p-4">

--- a/packages/plugin-analytics-dashboard/src/components/analytics-settings.tsx
+++ b/packages/plugin-analytics-dashboard/src/components/analytics-settings.tsx
@@ -1,0 +1,122 @@
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import {
+  Button,
+  Input,
+  Label,
+  Skeleton,
+  useSettingsContext,
+} from "@kitejs-cms/dashboard-core";
+import type { AnalyticsPluginSettingsModel } from "@kitejs-cms/plugin-analytics-api";
+import {
+  ANALYTICS_PLUGIN_NAMESPACE,
+  ANALYTICS_SETTINGS_KEY,
+} from "../module";
+
+export function AnalyticsSettings() {
+  const { t } = useTranslation("analytics");
+  const { t: tCore } = useTranslation("core");
+  const {
+    getSetting,
+    updateSetting,
+    hasUnsavedChanges,
+    setHasUnsavedChanges,
+  } = useSettingsContext();
+
+  const [settings, setSettings] =
+    useState<AnalyticsPluginSettingsModel | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const loadSettings = async () => {
+      try {
+        const res = await getSetting<{ value: AnalyticsPluginSettingsModel }>(
+          ANALYTICS_PLUGIN_NAMESPACE,
+          ANALYTICS_SETTINGS_KEY,
+        );
+        if (res?.value) {
+          setSettings(res.value);
+        }
+      } catch (err) {
+        console.error("Failed to load analytics settings", err);
+      } finally {
+        setLoading(false);
+      }
+    };
+    loadSettings();
+  }, [getSetting]);
+
+  const handleRetentionChange = (val: string) => {
+    setSettings((prev) =>
+      prev ? { ...prev, retentionDays: parseInt(val, 10) || 0 } : prev,
+    );
+    setHasUnsavedChanges(true);
+  };
+
+  const regenerateApiKey = () => {
+    setSettings((prev) =>
+      prev ? { ...prev, apiKey: crypto.randomUUID() } : prev,
+    );
+    setHasUnsavedChanges(true);
+  };
+
+  const handleSave = async () => {
+    if (!settings) return;
+    setLoading(true);
+    try {
+      await updateSetting(
+        ANALYTICS_PLUGIN_NAMESPACE,
+        ANALYTICS_SETTINGS_KEY,
+        settings,
+      );
+      setHasUnsavedChanges(false);
+    } catch (err) {
+      console.error("Failed to save analytics settings", err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (loading && !settings) {
+    return (
+      <div className="space-y-6">
+        <Skeleton className="h-10 w-full" />
+        <Skeleton className="h-10 w-full" />
+        <Skeleton className="h-10 w-24 ml-auto" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6 pb-16">
+      <div className="space-y-2">
+        <Label htmlFor="apiKey">{t("settings.general.apiKey")}</Label>
+        <div className="flex gap-2">
+          <Input id="apiKey" value={settings?.apiKey ?? ""} readOnly />
+          <Button type="button" variant="outline" onClick={regenerateApiKey}>
+            {t("settings.general.regenerate")}
+          </Button>
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="retentionDays">
+          {t("settings.general.retentionDays")}
+        </Label>
+        <Input
+          id="retentionDays"
+          type="number"
+          value={settings?.retentionDays ?? 0}
+          onChange={(e) => handleRetentionChange(e.target.value)}
+        />
+      </div>
+
+      <div className="fixed bottom-4 right-4 p-4">
+        <Button onClick={handleSave} disabled={!hasUnsavedChanges || loading}>
+          {tCore("common.save")}
+        </Button>
+      </div>
+    </div>
+  );
+}
+

--- a/packages/plugin-analytics-dashboard/src/locales/en.json
+++ b/packages/plugin-analytics-dashboard/src/locales/en.json
@@ -62,10 +62,10 @@
   "settings": {
     "description": "Configure analytics settings.",
     "general": {
-      "title": "General",
       "apiKey": "API key",
       "regenerate": "Regenerate",
-      "retentionDays": "Retention days"
+      "retentionDays": "Retention days",
+      "noRetention": "Never delete events"
     }
   }
 }

--- a/packages/plugin-analytics-dashboard/src/locales/en.json
+++ b/packages/plugin-analytics-dashboard/src/locales/en.json
@@ -58,5 +58,14 @@
     "newUsers": "New users",
     "viewDetails": "View analytics",
     "trendChartAriaLabel": "Visitors and new users chart"
+  },
+  "settings": {
+    "description": "Configure analytics settings.",
+    "general": {
+      "title": "General",
+      "apiKey": "API key",
+      "regenerate": "Regenerate",
+      "retentionDays": "Retention days"
+    }
   }
 }

--- a/packages/plugin-analytics-dashboard/src/locales/it.json
+++ b/packages/plugin-analytics-dashboard/src/locales/it.json
@@ -62,10 +62,10 @@
   "settings": {
     "description": "Configura le impostazioni di analytics.",
     "general": {
-      "title": "Generali",
       "apiKey": "API key",
       "regenerate": "Rigenera",
-      "retentionDays": "Giorni di conservazione"
+      "retentionDays": "Giorni di conservazione",
+      "noRetention": "Non eliminare gli eventi"
     }
   }
 }

--- a/packages/plugin-analytics-dashboard/src/locales/it.json
+++ b/packages/plugin-analytics-dashboard/src/locales/it.json
@@ -58,5 +58,14 @@
     "newUsers": "Nuovi utenti",
     "viewDetails": "Vai a Analytics",
     "trendChartAriaLabel": "Grafico visitatori e nuovi utenti"
+  },
+  "settings": {
+    "description": "Configura le impostazioni di analytics.",
+    "general": {
+      "title": "Generali",
+      "apiKey": "API key",
+      "regenerate": "Rigenera",
+      "retentionDays": "Giorni di conservazione"
+    }
   }
 }

--- a/packages/plugin-analytics-dashboard/src/module.tsx
+++ b/packages/plugin-analytics-dashboard/src/module.tsx
@@ -22,14 +22,7 @@ export const AnalyticsModule: DashboardModule = {
     title: "analytics:menu.analytics",
     icon: <BarChart3 />,
     description: "analytics:settings.description",
-    children: [
-      {
-        key: "analytics-general",
-        title: "analytics:settings.general.title",
-        icon: <BarChart3 />,
-        component: <AnalyticsSettings />,
-      },
-    ],
+    component: <AnalyticsSettings />,
   },
   routes: [
     {

--- a/packages/plugin-analytics-dashboard/src/module.tsx
+++ b/packages/plugin-analytics-dashboard/src/module.tsx
@@ -4,6 +4,7 @@ import { AnalyticsOverviewPage } from "./pages/analytics-overview";
 import { AnalyticsEventsPage } from "./pages/analytics-events";
 import { AnalyticsTechnologiesPage } from "./pages/analytics-technologies";
 import { AnalyticsDashboardWidget } from "./components/analytics-dashboard-widget";
+import { AnalyticsSettings } from "./components/analytics-settings";
 
 export const ANALYTICS_PLUGIN_NAMESPACE = "analytics";
 export const ANALYTICS_SETTINGS_KEY = `${ANALYTICS_PLUGIN_NAMESPACE}:config`;
@@ -16,6 +17,20 @@ export const AnalyticsModule: DashboardModule = {
   key: ANALYTICS_PLUGIN_NAMESPACE,
   name: "analytics",
   translations: { it, en },
+  settings: {
+    key: ANALYTICS_PLUGIN_NAMESPACE,
+    title: "analytics:menu.analytics",
+    icon: <BarChart3 />,
+    description: "analytics:settings.description",
+    children: [
+      {
+        key: "analytics-general",
+        title: "analytics:settings.general.title",
+        icon: <BarChart3 />,
+        component: <AnalyticsSettings />,
+      },
+    ],
+  },
   routes: [
     {
       path: "analytics",

--- a/packages/plugin-analytics-dashboard/src/pages/analytics-events.tsx
+++ b/packages/plugin-analytics-dashboard/src/pages/analytics-events.tsx
@@ -169,7 +169,7 @@ export function AnalyticsEventsPage() {
     const newLabels = { ...typeLabels, [editType]: editLabelValue };
     setTypeLabels(newLabels);
     const newSettings: AnalyticsPluginSettingsModel = {
-      ...(pluginSettings ?? { apiKey: "", retentionDays: 0 }),
+      ...(pluginSettings ?? { apiKey: "", retentionDays: null }),
       eventTypeLabels: newLabels,
     };
     setPluginSettings(newSettings);


### PR DESCRIPTION
## Summary
- add settings section and translations for analytics plugin
- implement AnalyticsSettings component to manage API key and retention

## Testing
- `pnpm --filter @kitejs-cms/plugin-analytics-dashboard lint`
- `pnpm --filter @kitejs-cms/plugin-analytics-dashboard check-types` *(fails: Cannot find module 'react' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68c66f276b6c8328850cb451e2a233ee