### PR TITLE
feat: make main menu customizable

### DIFF
--- a/packages/dashboard-core/src/components/app-sidebar.tsx
+++ b/packages/dashboard-core/src/components/app-sidebar.tsx
@@ -5,7 +5,6 @@ import {
   Command,
   LayoutDashboard,
   GripVertical,
-  Settings,
   X,
   Check,
   Plus,
@@ -80,6 +79,11 @@ export function AppSidebar({
   const [editing, setEditing] = React.useState(false);
   const [draggedIndex, setDraggedIndex] = React.useState<number | null>(null);
   const [dragOverIndex, setDragOverIndex] = React.useState<number | null>(null);
+
+  const startEditing = React.useCallback(() => {
+    setOriginalLayout(layout);
+    setEditing(true);
+  }, [layout]);
 
   React.useEffect(() => {
     (async () => {
@@ -246,12 +250,17 @@ export function AppSidebar({
           </div>
         ) : (
           menuGroups.map((group, index) => (
-            <NavMain key={index} title={group.title} items={group.items as never} />
+            <NavMain
+              key={index}
+              title={group.title}
+              items={group.items as never}
+              onSettings={startEditing}
+            />
           ))
         )}
       </SidebarContent>
       <SidebarFooter className="flex flex-col gap-2">
-        {editing ? (
+        {editing && (
           <div className="flex gap-2 px-2">
             <Button
               variant="ghost"
@@ -270,18 +279,6 @@ export function AppSidebar({
               <Check className="h-4 w-4" />
             </Button>
           </div>
-        ) : (
-          <Button
-            variant="ghost"
-            size="icon"
-            onClick={() => {
-              setOriginalLayout(layout);
-              setEditing(true);
-            }}
-            aria-label="Customize Menu"
-          >
-            <Settings className="h-4 w-4" />
-          </Button>
         )}
         {user && (
           <NavUser

--- a/packages/dashboard-core/src/components/app-sidebar.tsx
+++ b/packages/dashboard-core/src/components/app-sidebar.tsx
@@ -25,7 +25,7 @@ import {
 import { useSettingsContext } from "../context/settings-context";
 import { Button } from "../components/ui/button";
 import { useTranslation } from "react-i18next";
-import { DashboardMenuSettingsModel } from "../models/dashboard-menu-settings.model";
+import { DashboardLayoutSettingsModel } from "../models/dashboard-layout-settings.model";
 
 export function AppSidebar({
   items = [],
@@ -81,12 +81,12 @@ export function AppSidebar({
   React.useEffect(() => {
     (async () => {
       const stored =
-        await getSetting<{ value: DashboardMenuSettingsModel }>(
+        await getSetting<{ value: DashboardLayoutSettingsModel }>(
           "dashboard",
-          "dashboard:menu"
+          "dashboard:layout"
         );
-      if (stored?.value?.order?.length) {
-        setLayout(stored.value.order);
+      if (stored?.value?.menu?.length) {
+        setLayout(stored.value.menu);
       } else {
         setLayout(defaultItems.map((i) => i.key!));
       }
@@ -133,7 +133,14 @@ export function AppSidebar({
   };
 
   const handleSave = async () => {
-    await updateSetting("dashboard", "dashboard:menu", { order: layout });
+    const existing = await getSetting<{ value: DashboardLayoutSettingsModel }>(
+      "dashboard",
+      "dashboard:layout"
+    );
+    await updateSetting("dashboard", "dashboard:layout", {
+      ...(existing?.value ?? {}),
+      menu: layout,
+    });
     setEditing(false);
   };
 

--- a/packages/dashboard-core/src/components/app-sidebar.tsx
+++ b/packages/dashboard-core/src/components/app-sidebar.tsx
@@ -57,7 +57,10 @@ export function AppSidebar({
     [hasPermission]
   );
 
-  const filteredItems = filterItems(items);
+  const filteredItems = React.useMemo(
+    () => filterItems(items),
+    [filterItems, items]
+  );
 
   const defaultItems = React.useMemo(
     () => [
@@ -97,11 +100,14 @@ export function AppSidebar({
   }, []);
 
   React.useEffect(() => {
+    const keys = defaultItems.map((i) => i.key!);
     setLayout((prev) => {
-      const keys = defaultItems.map((i) => i.key!);
       const existing = prev.filter((k) => keys.includes(k));
       const missing = keys.filter((k) => !existing.includes(k));
-      return [...existing, ...missing];
+      const next = [...existing, ...missing];
+      return next.length === prev.length && next.every((k, i) => k === prev[i])
+        ? prev
+        : next;
     });
   }, [defaultItems]);
 

--- a/packages/dashboard-core/src/components/app-sidebar.tsx
+++ b/packages/dashboard-core/src/components/app-sidebar.tsx
@@ -25,6 +25,7 @@ import { useSettingsContext } from "../context/settings-context";
 import { Button } from "../components/ui/button";
 import { useTranslation } from "react-i18next";
 import { DashboardLayoutSettingsModel } from "../models/dashboard-layout-settings.model";
+import { Skeleton } from "../components/ui/skeleton";
 
 export function AppSidebar({
   items = [],
@@ -169,11 +170,6 @@ export function AppSidebar({
     setLayout(originalLayout);
     setEditing(false);
   };
-
-  if (!layoutLoaded) {
-    return null;
-  }
-
   const orderedItems = React.useMemo(
     () => displayed.map((key) => itemMap.get(key)!).filter(Boolean),
     [displayed, itemMap]
@@ -210,7 +206,13 @@ export function AppSidebar({
         </SidebarMenu>
       </SidebarHeader>
       <SidebarContent>
-        {editing ? (
+        {!layoutLoaded ? (
+          <div className="space-y-2 p-2">
+            {defaultItems.map((_, i) => (
+              <Skeleton key={i} className="h-8 w-full" />
+            ))}
+          </div>
+        ) : editing ? (
           <div className="p-2">
             <div className="mb-2 flex justify-end gap-2">
               <Button

--- a/packages/dashboard-core/src/components/app-sidebar.tsx
+++ b/packages/dashboard-core/src/components/app-sidebar.tsx
@@ -75,6 +75,7 @@ export function AppSidebar({
   );
 
   const [layout, setLayout] = React.useState<string[]>([]);
+  const [layoutLoaded, setLayoutLoaded] = React.useState(false);
   const [originalLayout, setOriginalLayout] = React.useState<string[]>([]);
   const [editing, setEditing] = React.useState(false);
   const [draggedIndex, setDraggedIndex] = React.useState<number | null>(null);
@@ -98,12 +99,15 @@ export function AppSidebar({
         }
       } catch {
         setLayout(defaultItems.map((i) => i.key!));
+      } finally {
+        setLayoutLoaded(true);
       }
     })();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   React.useEffect(() => {
+    if (!layoutLoaded) return;
     const keys = defaultItems.map((i) => i.key!);
     setLayout((prev) => {
       const existing = prev.filter((k) => keys.includes(k));
@@ -113,7 +117,7 @@ export function AppSidebar({
         ? prev
         : next;
     });
-  }, [defaultItems]);
+  }, [defaultItems, layoutLoaded]);
 
   const displayed = React.useMemo(
     () => layout.filter((key) => itemMap.has(key)),
@@ -165,6 +169,10 @@ export function AppSidebar({
     setLayout(originalLayout);
     setEditing(false);
   };
+
+  if (!layoutLoaded) {
+    return null;
+  }
 
   const orderedItems = React.useMemo(
     () => displayed.map((key) => itemMap.get(key)!).filter(Boolean),
@@ -228,18 +236,20 @@ export function AppSidebar({
                 if (!item) return null;
                 return (
                   <React.Fragment key={key}>
-                    <div
-                      onDragOver={(e) => {
-                        e.preventDefault();
-                        setDragOverIndex(index);
-                      }}
-                      onDrop={handleDrop}
-                      className={`h-8 rounded-md border-2 border-dashed ${
-                        dragOverIndex === index
-                          ? "border-sidebar-accent"
-                          : "border-border"
-                      }`}
-                    />
+                    {draggedIndex !== null && (
+                      <div
+                        onDragOver={(e) => {
+                          e.preventDefault();
+                          setDragOverIndex(index);
+                        }}
+                        onDrop={handleDrop}
+                        className={`h-2 rounded-md border-2 border-dashed ${
+                          dragOverIndex === index
+                            ? "border-sidebar-accent"
+                            : "border-border"
+                        }`}
+                      />
+                    )}
                     <div
                       draggable
                       onDragStart={() => handleDragStart(index)}
@@ -264,18 +274,20 @@ export function AppSidebar({
                   </React.Fragment>
                 );
               })}
-              <div
-                onDragOver={(e) => {
-                  e.preventDefault();
-                  setDragOverIndex(layout.length);
-                }}
-                onDrop={handleDrop}
-                className={`h-8 rounded-md border-2 border-dashed ${
-                  dragOverIndex === layout.length
-                    ? "border-sidebar-accent"
-                    : "border-border"
-                }`}
-              />
+              {draggedIndex !== null && (
+                <div
+                  onDragOver={(e) => {
+                    e.preventDefault();
+                    setDragOverIndex(layout.length);
+                  }}
+                  onDrop={handleDrop}
+                  className={`h-2 rounded-md border-2 border-dashed ${
+                    dragOverIndex === layout.length
+                      ? "border-sidebar-accent"
+                      : "border-border"
+                  }`}
+                />
+              )}
             </div>
             {available.length > 0 && (
               <div className="pt-2">

--- a/packages/dashboard-core/src/components/app-sidebar.tsx
+++ b/packages/dashboard-core/src/components/app-sidebar.tsx
@@ -80,18 +80,21 @@ export function AppSidebar({
 
   React.useEffect(() => {
     (async () => {
-      const stored =
-        await getSetting<{ value: DashboardLayoutSettingsModel }>(
-          "dashboard",
-          "dashboard:layout"
-        );
-      if (stored?.value?.menu?.length) {
-        setLayout(stored.value.menu);
-      } else {
+      try {
+        const stored = await getSetting<{
+          value: DashboardLayoutSettingsModel;
+        }>("dashboard", "dashboard:layout");
+        if (stored?.value?.menu?.length) {
+          setLayout(stored.value.menu);
+        } else {
+          setLayout(defaultItems.map((i) => i.key!));
+        }
+      } catch {
         setLayout(defaultItems.map((i) => i.key!));
       }
     })();
-  }, [getSetting, defaultItems]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   React.useEffect(() => {
     setLayout((prev) => {

--- a/packages/dashboard-core/src/components/app-sidebar.tsx
+++ b/packages/dashboard-core/src/components/app-sidebar.tsx
@@ -130,7 +130,15 @@ export function AppSidebar({
     [defaultItems, layout]
   );
 
-  const handleDragStart = (index: number) => setDraggedIndex(index);
+  const handleDragStart = (
+    event: React.DragEvent<HTMLDivElement>,
+    index: number
+  ) => {
+    event.dataTransfer.effectAllowed = "move";
+    // Firefox requires data to be set for drag to initiate
+    event.dataTransfer.setData("text/plain", "");
+    setDraggedIndex(index);
+  };
 
   const handleDrop = () => {
     if (draggedIndex === null || dragOverIndex === null) return;
@@ -209,7 +217,13 @@ export function AppSidebar({
         {!layoutLoaded ? (
           <div className="space-y-2 p-2">
             {defaultItems.map((_, i) => (
-              <Skeleton key={i} className="h-8 w-full" />
+              <div
+                key={i}
+                className="flex items-center gap-2 rounded-md px-2 py-1.5"
+              >
+                <Skeleton className="h-4 w-4 rounded" />
+                <Skeleton className="h-4 flex-1" />
+              </div>
             ))}
           </div>
         ) : editing ? (
@@ -254,7 +268,7 @@ export function AppSidebar({
                     )}
                     <div
                       draggable
-                      onDragStart={() => handleDragStart(index)}
+                      onDragStart={(e) => handleDragStart(e, index)}
                       onDragEnd={() => {
                         setDraggedIndex(null);
                         setDragOverIndex(null);

--- a/packages/dashboard-core/src/components/app-sidebar.tsx
+++ b/packages/dashboard-core/src/components/app-sidebar.tsx
@@ -140,12 +140,16 @@ export function AppSidebar({
     setDraggedIndex(index);
   };
 
-  const handleDrop = () => {
-    if (draggedIndex === null || dragOverIndex === null) return;
+  const handleDrop = (
+    event: React.DragEvent<HTMLDivElement>,
+    dropIndex: number
+  ) => {
+    event.preventDefault();
+    if (draggedIndex === null) return;
     const newLayout = [...layout];
     const [moved] = newLayout.splice(draggedIndex, 1);
-    let index = dragOverIndex;
-    if (draggedIndex < dragOverIndex) {
+    let index = dropIndex;
+    if (draggedIndex < dropIndex) {
       index -= 1;
     }
     newLayout.splice(index, 0, moved);
@@ -258,8 +262,8 @@ export function AppSidebar({
                           e.preventDefault();
                           setDragOverIndex(index);
                         }}
-                        onDrop={handleDrop}
-                        className={`h-2 rounded-md border-2 border-dashed ${
+                        onDrop={(e) => handleDrop(e, index)}
+                        className={`h-6 rounded-md border-2 border-dashed ${
                           dragOverIndex === index
                             ? "border-sidebar-accent"
                             : "border-border"
@@ -296,8 +300,8 @@ export function AppSidebar({
                     e.preventDefault();
                     setDragOverIndex(layout.length);
                   }}
-                  onDrop={handleDrop}
-                  className={`h-2 rounded-md border-2 border-dashed ${
+                  onDrop={(e) => handleDrop(e, layout.length)}
+                  className={`h-6 rounded-md border-2 border-dashed ${
                     dragOverIndex === layout.length
                       ? "border-sidebar-accent"
                       : "border-border"

--- a/packages/dashboard-core/src/components/app-sidebar.tsx
+++ b/packages/dashboard-core/src/components/app-sidebar.tsx
@@ -1,7 +1,15 @@
 import * as React from "react";
 import { SidebarMenuItemModel as ItemModule } from "../models/module.model";
 import { useAuthContext } from "../context/auth-context";
-import { Command, LayoutDashboard } from "lucide-react";
+import {
+  Command,
+  LayoutDashboard,
+  GripVertical,
+  Settings,
+  X,
+  Check,
+  Plus,
+} from "lucide-react";
 import { NavMain } from "../components/nav-main";
 import { NavUser } from "../components/nav-user";
 import { useHasPermission } from "../hooks/use-has-permission";
@@ -15,6 +23,9 @@ import {
   SidebarMenuItem,
 } from "../components/ui/sidebar";
 import { useSettingsContext } from "../context/settings-context";
+import { Button } from "../components/ui/button";
+import { useTranslation } from "react-i18next";
+import { DashboardMenuSettingsModel } from "../models/dashboard-menu-settings.model";
 
 export function AppSidebar({
   items = [],
@@ -24,35 +35,122 @@ export function AppSidebar({
   items?: ItemModule[];
   openSettings?: () => void;
 }) {
-  const { cmsSettings } = useSettingsContext();
+  const { cmsSettings, getSetting, updateSetting } = useSettingsContext();
   const { user } = useAuthContext();
   const hasPermission = useHasPermission();
+  const { t } = useTranslation();
 
-  const filterItems = (list: ItemModule[]): ItemModule[] =>
-    list
-      .filter(
-        (item) =>
-          !item.requiredPermissions ||
-          hasPermission(item.requiredPermissions)
-      )
-      .map((item) => ({
-        ...item,
-        items: item.items ? filterItems(item.items as ItemModule[]) : undefined,
-      }));
+  const filterItems = React.useCallback(
+    (list: ItemModule[]): ItemModule[] =>
+      list
+        .filter(
+          (item) =>
+            !item.requiredPermissions ||
+            hasPermission(item.requiredPermissions)
+        )
+        .map((item) => ({
+          ...item,
+          items: item.items
+            ? filterItems(item.items as ItemModule[])
+            : undefined,
+        })),
+    [hasPermission]
+  );
 
   const filteredItems = filterItems(items);
 
-  const allItems = [
+  const defaultItems = React.useMemo(
+    () => [
+      { key: "dashboard", title: "Dashboard", url: "/", icon: LayoutDashboard },
+      ...filteredItems,
+    ],
+    [filteredItems]
+  );
+
+  const itemMap = React.useMemo(
+    () => new Map(defaultItems.map((item) => [item.key!, item])),
+    [defaultItems]
+  );
+
+  const [layout, setLayout] = React.useState<string[]>([]);
+  const [originalLayout, setOriginalLayout] = React.useState<string[]>([]);
+  const [editing, setEditing] = React.useState(false);
+  const [draggedIndex, setDraggedIndex] = React.useState<number | null>(null);
+  const [dragOverIndex, setDragOverIndex] = React.useState<number | null>(null);
+
+  React.useEffect(() => {
+    (async () => {
+      const stored =
+        await getSetting<{ value: DashboardMenuSettingsModel }>(
+          "dashboard",
+          "dashboard:menu"
+        );
+      if (stored?.value?.order?.length) {
+        setLayout(stored.value.order);
+      } else {
+        setLayout(defaultItems.map((i) => i.key!));
+      }
+    })();
+  }, [getSetting, defaultItems]);
+
+  React.useEffect(() => {
+    setLayout((prev) => {
+      const keys = defaultItems.map((i) => i.key!);
+      const existing = prev.filter((k) => keys.includes(k));
+      const missing = keys.filter((k) => !existing.includes(k));
+      return [...existing, ...missing];
+    });
+  }, [defaultItems]);
+
+  const displayed = React.useMemo(
+    () => layout.filter((key) => itemMap.has(key)),
+    [layout, itemMap]
+  );
+
+  const available = React.useMemo(
+    () => defaultItems.filter((item) => !layout.includes(item.key!)),
+    [defaultItems, layout]
+  );
+
+  const handleDragStart = (index: number) => setDraggedIndex(index);
+
+  const handleDrop = (index: number) => {
+    if (draggedIndex === null || draggedIndex === index) return;
+    const newLayout = [...layout];
+    const [moved] = newLayout.splice(draggedIndex, 1);
+    newLayout.splice(index, 0, moved);
+    setLayout(newLayout);
+    setDraggedIndex(null);
+    setDragOverIndex(null);
+  };
+
+  const handleRemove = (key: string) => {
+    setLayout(layout.filter((k) => k !== key));
+  };
+
+  const handleAdd = (key: string) => {
+    setLayout([...layout, key]);
+  };
+
+  const handleSave = async () => {
+    await updateSetting("dashboard", "dashboard:menu", { order: layout });
+    setEditing(false);
+  };
+
+  const handleCancel = () => {
+    setLayout(originalLayout);
+    setEditing(false);
+  };
+
+  const orderedItems = React.useMemo(
+    () => displayed.map((key) => itemMap.get(key)!).filter(Boolean),
+    [displayed, itemMap]
+  );
+
+  const menuGroups = [
     {
       title: "Main Menu",
-      items: [
-        {
-          title: "Dashboard",
-          url: "/",
-          icon: LayoutDashboard,
-        },
-        ...filteredItems,
-      ],
+      items: orderedItems,
     },
   ];
 
@@ -80,15 +178,95 @@ export function AppSidebar({
         </SidebarMenu>
       </SidebarHeader>
       <SidebarContent>
-        {allItems.map((group, index) => (
-          <NavMain
-            key={index}
-            title={group.title}
-            items={group.items as never}
-          />
-        ))}
+        {editing ? (
+          <div className="p-2 space-y-2">
+            {displayed.map((key, index) => {
+              const item = itemMap.get(key)!;
+              return (
+                <div
+                  key={key}
+                  draggable
+                  onDragStart={() => handleDragStart(index)}
+                  onDragOver={(e) => {
+                    e.preventDefault();
+                    setDragOverIndex(index);
+                  }}
+                  onDrop={() => handleDrop(index)}
+                  className={`flex items-center gap-2 rounded-md border p-2 ${
+                    dragOverIndex === index
+                      ? "border-sidebar-accent"
+                      : "border-transparent"
+                  }`}
+                >
+                  <GripVertical className="h-4 w-4 text-gray-400" />
+                  <span className="flex-1">{t(item.title)}</span>
+                  {key !== "dashboard" && (
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      onClick={() => handleRemove(key)}
+                    >
+                      <X className="h-4 w-4" />
+                    </Button>
+                  )}
+                </div>
+              );
+            })}
+            {available.length > 0 && (
+              <div className="pt-2">
+                {available.map((item) => (
+                  <Button
+                    key={item.key}
+                    variant="outline"
+                    className="w-full justify-start mb-2"
+                    onClick={() => handleAdd(item.key!)}
+                  >
+                    <Plus className="mr-2 h-4 w-4" />
+                    {t(item.title)}
+                  </Button>
+                ))}
+              </div>
+            )}
+          </div>
+        ) : (
+          menuGroups.map((group, index) => (
+            <NavMain key={index} title={group.title} items={group.items as never} />
+          ))
+        )}
       </SidebarContent>
-      <SidebarFooter>
+      <SidebarFooter className="flex flex-col gap-2">
+        {editing ? (
+          <div className="flex gap-2 px-2">
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={handleCancel}
+              aria-label="Cancel"
+            >
+              <X className="h-4 w-4" />
+            </Button>
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={handleSave}
+              aria-label="Save"
+            >
+              <Check className="h-4 w-4" />
+            </Button>
+          </div>
+        ) : (
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={() => {
+              setOriginalLayout(layout);
+              setEditing(true);
+            }}
+            aria-label="Customize Menu"
+          >
+            <Settings className="h-4 w-4" />
+          </Button>
+        )}
         {user && (
           <NavUser
             openSettings={openSettings}

--- a/packages/dashboard-core/src/components/app-sidebar.tsx
+++ b/packages/dashboard-core/src/components/app-sidebar.tsx
@@ -127,10 +127,14 @@ export function AppSidebar({
 
   const handleDragStart = (index: number) => setDraggedIndex(index);
 
-  const handleDrop = (index: number) => {
-    if (draggedIndex === null || draggedIndex === index) return;
+  const handleDrop = () => {
+    if (draggedIndex === null || dragOverIndex === null) return;
     const newLayout = [...layout];
     const [moved] = newLayout.splice(draggedIndex, 1);
+    let index = dragOverIndex;
+    if (draggedIndex < dragOverIndex) {
+      index -= 1;
+    }
     newLayout.splice(index, 0, moved);
     setLayout(newLayout);
     setDraggedIndex(null);
@@ -199,46 +203,87 @@ export function AppSidebar({
       </SidebarHeader>
       <SidebarContent>
         {editing ? (
-          <div className="p-2 space-y-2">
-            {displayed.map((key, index) => {
-              const item = itemMap.get(key)!;
-              return (
-                <div
-                  key={key}
-                  draggable
-                  onDragStart={() => handleDragStart(index)}
-                  onDragOver={(e) => {
-                    e.preventDefault();
-                    setDragOverIndex(index);
-                  }}
-                  onDrop={() => handleDrop(index)}
-                  className={`flex items-center gap-2 rounded-md border p-2 ${
-                    dragOverIndex === index
-                      ? "border-sidebar-accent"
-                      : "border-transparent"
-                  }`}
-                >
-                  <GripVertical className="h-4 w-4 text-gray-400" />
-                  <span className="flex-1">{t(item.title)}</span>
-                  {key !== "dashboard" && (
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      onClick={() => handleRemove(key)}
+          <div className="p-2">
+            <div className="mb-2 flex justify-end gap-2">
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={handleCancel}
+                aria-label="Cancel"
+              >
+                <X className="h-4 w-4" />
+              </Button>
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={handleSave}
+                aria-label="Save"
+              >
+                <Check className="h-4 w-4" />
+              </Button>
+            </div>
+            <div className="flex flex-col gap-2">
+              {layout.map((key, index) => {
+                const item = itemMap.get(key);
+                if (!item) return null;
+                return (
+                  <React.Fragment key={key}>
+                    <div
+                      onDragOver={(e) => {
+                        e.preventDefault();
+                        setDragOverIndex(index);
+                      }}
+                      onDrop={handleDrop}
+                      className={`h-8 rounded-md border-2 border-dashed ${
+                        dragOverIndex === index
+                          ? "border-sidebar-accent"
+                          : "border-border"
+                      }`}
+                    />
+                    <div
+                      draggable
+                      onDragStart={() => handleDragStart(index)}
+                      onDragEnd={() => {
+                        setDraggedIndex(null);
+                        setDragOverIndex(null);
+                      }}
+                      className="flex items-center gap-2 rounded-md border border-border bg-background p-2"
                     >
-                      <X className="h-4 w-4" />
-                    </Button>
-                  )}
-                </div>
-              );
-            })}
+                      <GripVertical className="h-4 w-4 text-gray-400" />
+                      <span className="flex-1">{t(item.title)}</span>
+                      {key !== "dashboard" && (
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          onClick={() => handleRemove(key)}
+                        >
+                          <X className="h-4 w-4" />
+                        </Button>
+                      )}
+                    </div>
+                  </React.Fragment>
+                );
+              })}
+              <div
+                onDragOver={(e) => {
+                  e.preventDefault();
+                  setDragOverIndex(layout.length);
+                }}
+                onDrop={handleDrop}
+                className={`h-8 rounded-md border-2 border-dashed ${
+                  dragOverIndex === layout.length
+                    ? "border-sidebar-accent"
+                    : "border-border"
+                }`}
+              />
+            </div>
             {available.length > 0 && (
               <div className="pt-2">
                 {available.map((item) => (
                   <Button
                     key={item.key}
                     variant="outline"
-                    className="w-full justify-start mb-2"
+                    className="mb-2 w-full justify-start"
                     onClick={() => handleAdd(item.key!)}
                   >
                     <Plus className="mr-2 h-4 w-4" />
@@ -260,26 +305,6 @@ export function AppSidebar({
         )}
       </SidebarContent>
       <SidebarFooter className="flex flex-col gap-2">
-        {editing && (
-          <div className="flex gap-2 px-2">
-            <Button
-              variant="ghost"
-              size="icon"
-              onClick={handleCancel}
-              aria-label="Cancel"
-            >
-              <X className="h-4 w-4" />
-            </Button>
-            <Button
-              variant="ghost"
-              size="icon"
-              onClick={handleSave}
-              aria-label="Save"
-            >
-              <Check className="h-4 w-4" />
-            </Button>
-          </div>
-        )}
         {user && (
           <NavUser
             openSettings={openSettings}

--- a/packages/dashboard-core/src/components/nav-main.tsx
+++ b/packages/dashboard-core/src/components/nav-main.tsx
@@ -1,4 +1,4 @@
-import { ChevronRight, LucideIcon } from "lucide-react";
+import { ChevronRight, LucideIcon, Settings } from "lucide-react";
 import {
   SidebarGroup,
   SidebarGroupLabel,
@@ -17,12 +17,15 @@ import {
 } from "./ui/collapsible";
 import { useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
+import { Button } from "./ui/button";
 
 export function NavMain({
   items,
   title,
+  onSettings,
 }: {
   title?: string;
+  onSettings?: () => void;
   items: {
     key?: string;
     title: string;
@@ -40,7 +43,21 @@ export function NavMain({
 
   return (
     <SidebarGroup>
-      {title && <SidebarGroupLabel>{title}</SidebarGroupLabel>}
+      {title && (
+        <div className="flex items-center justify-between">
+          <SidebarGroupLabel>{title}</SidebarGroupLabel>
+          {onSettings && (
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={onSettings}
+              aria-label="Customize Menu"
+            >
+              <Settings className="h-3 w-3" />
+            </Button>
+          )}
+        </div>
+      )}
       <SidebarMenu>
         {items.map((item) => (
           <Collapsible

--- a/packages/dashboard-core/src/components/nav-main.tsx
+++ b/packages/dashboard-core/src/components/nav-main.tsx
@@ -24,6 +24,7 @@ export function NavMain({
 }: {
   title?: string;
   items: {
+    key?: string;
     title: string;
     url: string;
     icon: LucideIcon;
@@ -43,7 +44,7 @@ export function NavMain({
       <SidebarMenu>
         {items.map((item) => (
           <Collapsible
-            key={item.title}
+            key={item.key ?? item.title}
             asChild
             defaultOpen={
               item.isActive ||

--- a/packages/dashboard-core/src/components/nav-main.tsx
+++ b/packages/dashboard-core/src/components/nav-main.tsx
@@ -50,6 +50,7 @@ export function NavMain({
             <Button
               variant="ghost"
               size="icon"
+              className="h-6 w-6"
               onClick={onSettings}
               aria-label="Customize Menu"
             >

--- a/packages/dashboard-core/src/dashboard-provider.tsx
+++ b/packages/dashboard-core/src/dashboard-provider.tsx
@@ -81,7 +81,9 @@ function DashboardRoutes({ modules }: { modules: DashboardModule[] }) {
 
   const menuItems = useMemo(
     () =>
-      enabledModules.filter((mod) => mod.menuItem).map((mod) => mod.menuItem),
+      enabledModules
+        .filter((mod) => mod.menuItem)
+        .map((mod) => ({ ...mod.menuItem!, key: mod.key })),
     [enabledModules]
   );
 

--- a/packages/dashboard-core/src/index.ts
+++ b/packages/dashboard-core/src/index.ts
@@ -45,6 +45,7 @@ export * from "./models/settings.model";
 export * from "./models/module.model";
 export * from "./models/dashboard-widget.model";
 export * from "./models/dashboard-widgets-settings.model";
+export * from "./models/dashboard-menu-settings.model";
 
 /* Hooks */
 export * from "./hooks/use-api";

--- a/packages/dashboard-core/src/index.ts
+++ b/packages/dashboard-core/src/index.ts
@@ -44,8 +44,7 @@ export * from "./models/menu-item.model";
 export * from "./models/settings.model";
 export * from "./models/module.model";
 export * from "./models/dashboard-widget.model";
-export * from "./models/dashboard-widgets-settings.model";
-export * from "./models/dashboard-menu-settings.model";
+export * from "./models/dashboard-layout-settings.model";
 
 /* Hooks */
 export * from "./hooks/use-api";

--- a/packages/dashboard-core/src/models/dashboard-layout-settings.model.ts
+++ b/packages/dashboard-core/src/models/dashboard-layout-settings.model.ts
@@ -10,6 +10,8 @@ export interface DashboardWidgetLayout {
   height: number;
 }
 
-export interface DashboardWidgetsSettingsModel {
+export interface DashboardLayoutSettingsModel {
   widgets: DashboardWidgetLayout[];
+  menu: string[];
 }
+

--- a/packages/dashboard-core/src/models/dashboard-menu-settings.model.ts
+++ b/packages/dashboard-core/src/models/dashboard-menu-settings.model.ts
@@ -1,7 +1,0 @@
-export interface DashboardMenuSettingsModel {
-  /**
-   * Ordered list of menu item keys to display in the main sidebar menu.
-   * Items not present in this list will be hidden.
-   */
-  order: string[];
-}

--- a/packages/dashboard-core/src/models/dashboard-menu-settings.model.ts
+++ b/packages/dashboard-core/src/models/dashboard-menu-settings.model.ts
@@ -1,0 +1,7 @@
+export interface DashboardMenuSettingsModel {
+  /**
+   * Ordered list of menu item keys to display in the main sidebar menu.
+   * Items not present in this list will be hidden.
+   */
+  order: string[];
+}

--- a/packages/dashboard-core/src/models/module.model.ts
+++ b/packages/dashboard-core/src/models/module.model.ts
@@ -13,6 +13,7 @@ export interface ModuleRouteModel {
 }
 
 export interface SidebarMenuItemModel {
+  key?: string;
   title: string;
   url?: string;
   icon: LucideIcon;

--- a/packages/dashboard-core/src/modules/core/pages/dashboard.tsx
+++ b/packages/dashboard-core/src/modules/core/pages/dashboard.tsx
@@ -3,8 +3,8 @@ import { DashboardWidgetModel } from "../../../models/dashboard-widget.model";
 import { useSettingsContext } from "../../../context/settings-context";
 import {
   DashboardWidgetLayout,
-  DashboardWidgetsSettingsModel,
-} from "../../../models/dashboard-widgets-settings.model";
+  DashboardLayoutSettingsModel,
+} from "../../../models/dashboard-layout-settings.model";
 import { Button } from "../../../components/ui/button";
 import {
   ArrowLeftRight,
@@ -32,9 +32,9 @@ export function DashboardPage({ widgets = [] }: DashboardPageProps) {
 
   useEffect(() => {
     (async () => {
-      const stored = await getSetting<{ value: DashboardWidgetsSettingsModel }>(
+      const stored = await getSetting<{ value: DashboardLayoutSettingsModel }>(
         "dashboard",
-        "dashboard:widgets"
+        "dashboard:layout"
       );
 
       if (stored?.value?.widgets?.length) {
@@ -134,7 +134,12 @@ export function DashboardPage({ widgets = [] }: DashboardPageProps) {
   };
 
   const handleSave = async () => {
-    await updateSetting("dashboard", "dashboard:widgets", {
+    const existing = await getSetting<{ value: DashboardLayoutSettingsModel }>(
+      "dashboard",
+      "dashboard:layout"
+    );
+    await updateSetting("dashboard", "dashboard:layout", {
+      ...(existing?.value ?? {}),
       widgets: layout,
     });
     setEditing(false);


### PR DESCRIPTION
## Summary
- allow dashboard menu items to be rearranged or hidden
- persist menu order with new `dashboard:menu` settings model
- support stable menu item keys for reliable ordering

## Testing
- `pnpm --filter @kitejs-cms/dashboard-core lint` *(fails: ESLint found too many warnings)*
- `pnpm --filter @kitejs-cms/dashboard-core check-types`


------
https://chatgpt.com/codex/tasks/task_e_68c6772d37bc83289be120471064f00c