### PR TITLE
feat: add commerce api plugin skeleton

### DIFF
--- a/packages/plugin-commerce-api/eslint.config.mjs
+++ b/packages/plugin-commerce-api/eslint.config.mjs
@@ -1,0 +1,4 @@
+import config from "@kitejs-cms/eslint-config/nest";
+
+/** @type {import("eslint").Linter.Config} */
+export default config;

--- a/packages/plugin-commerce-api/package.json
+++ b/packages/plugin-commerce-api/package.json
@@ -1,0 +1,68 @@
+{
+  "name": "@kitejs-cms/plugin-commerce-api",
+  "version": "0.0.1-alpha.0",
+  "license": "MIT",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "sideEffects": false,
+  "engines": {
+    "node": ">=18"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "./*": {
+      "import": "./dist/*.js",
+      "require": "./dist/*.js",
+      "types": "./dist/*.d.ts"
+    }
+  },
+  "scripts": {
+    "dev": "pnpm build --watch",
+    "build": "tsc -b -v",
+    "lint": "eslint \"{src,apps,libs,test}/**/*.ts\""
+  },
+  "peerDependencies": {
+    "@kitejs-cms/core": "workspace:*",
+    "@nestjs/common": "^11.0.0",
+    "@nestjs/config": "^4.0.0",
+    "@nestjs/core": "^11.0.0",
+    "@nestjs/jwt": "^11.0.0",
+    "@nestjs/mapped-types": "*",
+    "@nestjs/mongoose": "^11.0.0",
+    "@nestjs/passport": "^11.0.0",
+    "@nestjs/platform-express": "^11.0.0",
+    "@nestjs/swagger": "^11.0.0"
+  },
+  "dependencies": {
+    "class-transformer": "^0.5.1",
+    "class-validator": "^0.14.1",
+    "mongoose": "^8.10.1",
+    "passport-jwt": "^4.0.1",
+    "reflect-metadata": "^0.2.2",
+    "rxjs": "^7.8.2"
+  },
+  "devDependencies": {
+    "@kitejs-cms/eslint-config": "workspace:*",
+    "@kitejs-cms/typescript-config": "workspace:*",
+    "@nestjs/common": "^11.0.0",
+    "@nestjs/config": "^4.0.0",
+    "@nestjs/core": "^11.0.0",
+    "@nestjs/jwt": "^11.0.0",
+    "@nestjs/mapped-types": "*",
+    "@nestjs/mongoose": "^11.0.0",
+    "@nestjs/passport": "^11.0.0",
+    "@nestjs/platform-express": "^11.0.0",
+    "@nestjs/swagger": "^11.0.0",
+    "typescript": "^5.7.3"
+  }
+}

--- a/packages/plugin-commerce-api/src/commerce-plugin.module.ts
+++ b/packages/plugin-commerce-api/src/commerce-plugin.module.ts
@@ -1,0 +1,7 @@
+import { Module } from "@nestjs/common";
+import { CommerceModule } from "./commerce";
+
+@Module({
+  imports: [CommerceModule],
+})
+export class CommercePluginModule {}

--- a/packages/plugin-commerce-api/src/commerce/collections/collections.module.ts
+++ b/packages/plugin-commerce-api/src/commerce/collections/collections.module.ts
@@ -1,0 +1,20 @@
+import { Module } from "@nestjs/common";
+import { MongooseModule } from "@nestjs/mongoose";
+import {
+  ProductCollection,
+  ProductCollectionSchema,
+} from "./schemas/product-collection.schema";
+import { CollectionsService } from "./services/collections.service";
+import { CollectionsController } from "./controllers/collections.controller";
+
+@Module({
+  imports: [
+    MongooseModule.forFeature([
+      { name: ProductCollection.name, schema: ProductCollectionSchema },
+    ]),
+  ],
+  controllers: [CollectionsController],
+  providers: [CollectionsService],
+  exports: [CollectionsService],
+})
+export class CollectionsModule {}

--- a/packages/plugin-commerce-api/src/commerce/collections/controllers/collections.controller.ts
+++ b/packages/plugin-commerce-api/src/commerce/collections/controllers/collections.controller.ts
@@ -1,0 +1,78 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Patch,
+  Post,
+  UseGuards,
+} from "@nestjs/common";
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+} from "@nestjs/swagger";
+import {
+  JwtAuthGuard,
+  PermissionsGuard,
+  Permissions,
+  ValidateObjectIdPipe,
+} from "@kitejs-cms/core";
+import { CollectionsService } from "../services/collections.service";
+import { CreateCollectionDto } from "../dto/create-collection.dto";
+import { UpdateCollectionDto } from "../dto/update-collection.dto";
+import { COMMERCE_PLUGIN_NAMESPACE } from "../../../constants";
+
+@ApiTags("Commerce - Collections")
+@ApiBearerAuth()
+@UseGuards(JwtAuthGuard, PermissionsGuard)
+@Controller("commerce/collections")
+export class CollectionsController {
+  constructor(private readonly collectionsService: CollectionsService) {}
+
+  @Post()
+  @Permissions(`${COMMERCE_PLUGIN_NAMESPACE}:collections.create`)
+  @ApiOperation({ summary: "Create a new collection" })
+  @ApiResponse({ status: 201, description: "Collection created" })
+  create(@Body() dto: CreateCollectionDto) {
+    return this.collectionsService.create(dto);
+  }
+
+  @Get()
+  @Permissions(`${COMMERCE_PLUGIN_NAMESPACE}:collections.read`)
+  @ApiOperation({ summary: "List collections" })
+  @ApiResponse({ status: 200, description: "List of collections" })
+  findAll() {
+    return this.collectionsService.findAll();
+  }
+
+  @Get(":id")
+  @Permissions(`${COMMERCE_PLUGIN_NAMESPACE}:collections.read`)
+  @ApiOperation({ summary: "Retrieve a collection" })
+  @ApiResponse({ status: 200, description: "Collection detail" })
+  findOne(@Param("id", ValidateObjectIdPipe) id: string) {
+    return this.collectionsService.findOne(id);
+  }
+
+  @Patch(":id")
+  @Permissions(`${COMMERCE_PLUGIN_NAMESPACE}:collections.update`)
+  @ApiOperation({ summary: "Update a collection" })
+  @ApiResponse({ status: 200, description: "Collection updated" })
+  update(
+    @Param("id", ValidateObjectIdPipe) id: string,
+    @Body() dto: UpdateCollectionDto
+  ) {
+    return this.collectionsService.update(id, dto);
+  }
+
+  @Delete(":id")
+  @Permissions(`${COMMERCE_PLUGIN_NAMESPACE}:collections.delete`)
+  @ApiOperation({ summary: "Delete a collection" })
+  @ApiResponse({ status: 204, description: "Collection deleted" })
+  async remove(@Param("id", ValidateObjectIdPipe) id: string) {
+    await this.collectionsService.remove(id);
+    return { status: "ok" };
+  }
+}

--- a/packages/plugin-commerce-api/src/commerce/collections/dto/create-collection.dto.ts
+++ b/packages/plugin-commerce-api/src/commerce/collections/dto/create-collection.dto.ts
@@ -1,0 +1,63 @@
+import { Type } from "class-transformer";
+import {
+  IsArray,
+  IsBoolean,
+  IsNumber,
+  IsObject,
+  IsOptional,
+  IsString,
+  ValidateNested,
+} from "class-validator";
+
+export class CollectionSeoDto {
+  @IsOptional()
+  @IsString()
+  title?: string;
+
+  @IsOptional()
+  @IsString()
+  description?: string;
+}
+
+export class CreateCollectionDto {
+  @IsString()
+  title!: string;
+
+  @IsString()
+  handle!: string;
+
+  @IsOptional()
+  @IsString()
+  description?: string;
+
+  @IsOptional()
+  @IsBoolean()
+  isActive?: boolean;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
+  sortOrder?: number;
+
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  tags?: string[];
+
+  @IsOptional()
+  @IsString()
+  coverImage?: string;
+
+  @IsOptional()
+  @IsString()
+  parentId?: string;
+
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => CollectionSeoDto)
+  seo?: CollectionSeoDto;
+
+  @IsOptional()
+  @IsObject()
+  metadata?: Record<string, any>;
+}

--- a/packages/plugin-commerce-api/src/commerce/collections/dto/update-collection.dto.ts
+++ b/packages/plugin-commerce-api/src/commerce/collections/dto/update-collection.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from "@nestjs/mapped-types";
+import { CreateCollectionDto } from "./create-collection.dto";
+
+export class UpdateCollectionDto extends PartialType(CreateCollectionDto) {}

--- a/packages/plugin-commerce-api/src/commerce/collections/index.ts
+++ b/packages/plugin-commerce-api/src/commerce/collections/index.ts
@@ -1,0 +1,15 @@
+/* DTO */
+export * from "./dto/create-collection.dto";
+export * from "./dto/update-collection.dto";
+
+/* Schemas */
+export * from "./schemas/product-collection.schema";
+
+/* Services */
+export * from "./services/collections.service";
+
+/* Module */
+export * from "./collections.module";
+
+/* Controller */
+export * from "./controllers/collections.controller";

--- a/packages/plugin-commerce-api/src/commerce/collections/schemas/product-collection.schema.ts
+++ b/packages/plugin-commerce-api/src/commerce/collections/schemas/product-collection.schema.ts
@@ -1,0 +1,62 @@
+import { Prop, Schema, SchemaFactory } from "@nestjs/mongoose";
+import { Document, Schema as SchemaDb, Types } from "mongoose";
+import { COMMERCE_PLUGIN_NAMESPACE } from "../../../constants";
+
+@Schema({ _id: false })
+export class CollectionSeo {
+  @Prop({ type: String })
+  title?: string;
+
+  @Prop({ type: String })
+  description?: string;
+}
+
+export const CollectionSeoSchema = SchemaFactory.createForClass(CollectionSeo);
+
+@Schema({
+  collection: `${COMMERCE_PLUGIN_NAMESPACE}_collections`,
+  timestamps: true,
+  toJSON: { getters: true },
+})
+export class ProductCollection extends Document {
+  @Prop({ type: String, required: true })
+  title!: string;
+
+  @Prop({ type: String, required: true, unique: true, index: true })
+  handle!: string;
+
+  @Prop({ type: String })
+  description?: string;
+
+  @Prop({ type: Boolean, default: true })
+  isActive!: boolean;
+
+  @Prop({ type: Number, default: 0 })
+  sortOrder!: number;
+
+  @Prop({ type: [String], default: [] })
+  tags!: string[];
+
+  @Prop({ type: String })
+  coverImage?: string;
+
+  @Prop({ type: SchemaDb.ObjectId, ref: "ProductCollection" })
+  parent?: Types.ObjectId;
+
+  @Prop({ type: CollectionSeoSchema })
+  seo?: CollectionSeo;
+
+  @Prop({
+    type: SchemaDb.Types.Map,
+    of: SchemaDb.Types.Mixed,
+    default: {},
+  })
+  metadata?: Map<string, any>;
+}
+
+export const ProductCollectionSchema =
+  SchemaFactory.createForClass(ProductCollection);
+
+ProductCollectionSchema.index({ isActive: 1, sortOrder: 1 });
+
+export type ProductCollectionDocument = ProductCollection & Document;

--- a/packages/plugin-commerce-api/src/commerce/collections/services/collections.service.ts
+++ b/packages/plugin-commerce-api/src/commerce/collections/services/collections.service.ts
@@ -1,0 +1,93 @@
+import { Injectable, NotFoundException } from "@nestjs/common";
+import { InjectModel } from "@nestjs/mongoose";
+import { Model, Types } from "mongoose";
+import {
+  ProductCollection,
+  ProductCollectionDocument,
+} from "../schemas/product-collection.schema";
+import { CreateCollectionDto } from "../dto/create-collection.dto";
+import { UpdateCollectionDto } from "../dto/update-collection.dto";
+
+@Injectable()
+export class CollectionsService {
+  constructor(
+    @InjectModel(ProductCollection.name)
+    private readonly collectionModel: Model<ProductCollectionDocument>
+  ) {}
+
+  private mapParent(parentId?: string) {
+    if (!parentId) return undefined;
+    return new Types.ObjectId(parentId);
+  }
+
+  async create(dto: CreateCollectionDto): Promise<ProductCollectionDocument> {
+    const { parentId, metadata, seo, ...rest } = dto;
+
+    return this.collectionModel.create({
+      ...rest,
+      tags: rest.tags ?? [],
+      parent: this.mapParent(parentId),
+      metadata: metadata ?? {},
+      seo: seo ? { ...seo } : undefined,
+    });
+  }
+
+  async findAll(): Promise<ProductCollectionDocument[]> {
+    return this.collectionModel.find().sort({ sortOrder: 1 }).exec();
+  }
+
+  async findOne(id: string): Promise<ProductCollectionDocument> {
+    const collection = await this.collectionModel.findById(id).exec();
+    if (!collection) {
+      throw new NotFoundException(`Collection with ID ${id} not found`);
+    }
+    return collection;
+  }
+
+  async update(
+    id: string,
+    dto: UpdateCollectionDto
+  ): Promise<ProductCollectionDocument> {
+    const { parentId, metadata, seo, ...rest } = dto;
+
+    const updateData: Record<string, unknown> = {
+      ...rest,
+    };
+
+    if (parentId !== undefined) {
+      updateData.parent = parentId ? this.mapParent(parentId) : null;
+    }
+
+    if (metadata) {
+      updateData.metadata = metadata;
+    }
+
+    if (seo) {
+      updateData.seo = { ...seo };
+    }
+
+    const collection = await this.collectionModel
+      .findByIdAndUpdate(id, updateData, { new: true, runValidators: true })
+      .exec();
+
+    if (!collection) {
+      throw new NotFoundException(`Collection with ID ${id} not found`);
+    }
+
+    return collection;
+  }
+
+  async remove(id: string): Promise<void> {
+    const result = await this.collectionModel.findByIdAndDelete(id).exec();
+    if (!result) {
+      throw new NotFoundException(`Collection with ID ${id} not found`);
+    }
+
+    await this.collectionModel
+      .updateMany(
+        { parent: new Types.ObjectId(id) },
+        { $unset: { parent: 1 } }
+      )
+      .exec();
+  }
+}

--- a/packages/plugin-commerce-api/src/commerce/commerce.module.ts
+++ b/packages/plugin-commerce-api/src/commerce/commerce.module.ts
@@ -1,0 +1,11 @@
+import { Module } from "@nestjs/common";
+import { ProductsModule } from "./products/products.module";
+import { CollectionsModule } from "./collections/collections.module";
+import { CustomersModule } from "./customers/customers.module";
+import { OrdersModule } from "./orders/orders.module";
+
+@Module({
+  imports: [ProductsModule, CollectionsModule, CustomersModule, OrdersModule],
+  exports: [ProductsModule, CollectionsModule, CustomersModule, OrdersModule],
+})
+export class CommerceModule {}

--- a/packages/plugin-commerce-api/src/commerce/customers/controllers/customers.controller.ts
+++ b/packages/plugin-commerce-api/src/commerce/customers/controllers/customers.controller.ts
@@ -1,0 +1,78 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Patch,
+  Post,
+  UseGuards,
+} from "@nestjs/common";
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+} from "@nestjs/swagger";
+import {
+  JwtAuthGuard,
+  PermissionsGuard,
+  Permissions,
+  ValidateObjectIdPipe,
+} from "@kitejs-cms/core";
+import { CustomersService } from "../services/customers.service";
+import { CreateCustomerDto } from "../dto/create-customer.dto";
+import { UpdateCustomerDto } from "../dto/update-customer.dto";
+import { COMMERCE_PLUGIN_NAMESPACE } from "../../../constants";
+
+@ApiTags("Commerce - Customers")
+@ApiBearerAuth()
+@UseGuards(JwtAuthGuard, PermissionsGuard)
+@Controller("commerce/customers")
+export class CustomersController {
+  constructor(private readonly customersService: CustomersService) {}
+
+  @Post()
+  @Permissions(`${COMMERCE_PLUGIN_NAMESPACE}:customers.create`)
+  @ApiOperation({ summary: "Create a new customer" })
+  @ApiResponse({ status: 201, description: "Customer created" })
+  create(@Body() dto: CreateCustomerDto) {
+    return this.customersService.create(dto);
+  }
+
+  @Get()
+  @Permissions(`${COMMERCE_PLUGIN_NAMESPACE}:customers.read`)
+  @ApiOperation({ summary: "List customers" })
+  @ApiResponse({ status: 200, description: "List of customers" })
+  findAll() {
+    return this.customersService.findAll();
+  }
+
+  @Get(":id")
+  @Permissions(`${COMMERCE_PLUGIN_NAMESPACE}:customers.read`)
+  @ApiOperation({ summary: "Retrieve a customer" })
+  @ApiResponse({ status: 200, description: "Customer detail" })
+  findOne(@Param("id", ValidateObjectIdPipe) id: string) {
+    return this.customersService.findOne(id);
+  }
+
+  @Patch(":id")
+  @Permissions(`${COMMERCE_PLUGIN_NAMESPACE}:customers.update`)
+  @ApiOperation({ summary: "Update a customer" })
+  @ApiResponse({ status: 200, description: "Customer updated" })
+  update(
+    @Param("id", ValidateObjectIdPipe) id: string,
+    @Body() dto: UpdateCustomerDto
+  ) {
+    return this.customersService.update(id, dto);
+  }
+
+  @Delete(":id")
+  @Permissions(`${COMMERCE_PLUGIN_NAMESPACE}:customers.delete`)
+  @ApiOperation({ summary: "Delete a customer" })
+  @ApiResponse({ status: 204, description: "Customer deleted" })
+  async remove(@Param("id", ValidateObjectIdPipe) id: string) {
+    await this.customersService.remove(id);
+    return { status: "ok" };
+  }
+}

--- a/packages/plugin-commerce-api/src/commerce/customers/customers.module.ts
+++ b/packages/plugin-commerce-api/src/commerce/customers/customers.module.ts
@@ -1,0 +1,15 @@
+import { Module } from "@nestjs/common";
+import { MongooseModule } from "@nestjs/mongoose";
+import { Customer, CustomerSchema } from "./schemas/customer.schema";
+import { CustomersService } from "./services/customers.service";
+import { CustomersController } from "./controllers/customers.controller";
+
+@Module({
+  imports: [
+    MongooseModule.forFeature([{ name: Customer.name, schema: CustomerSchema }]),
+  ],
+  controllers: [CustomersController],
+  providers: [CustomersService],
+  exports: [CustomersService],
+})
+export class CustomersModule {}

--- a/packages/plugin-commerce-api/src/commerce/customers/dto/create-customer.dto.ts
+++ b/packages/plugin-commerce-api/src/commerce/customers/dto/create-customer.dto.ts
@@ -1,0 +1,106 @@
+import { Type } from "class-transformer";
+import {
+  IsArray,
+  IsBoolean,
+  IsEmail,
+  IsEnum,
+  IsObject,
+  IsOptional,
+  IsString,
+  ValidateNested,
+} from "class-validator";
+import { CustomerLifecycleStage } from "../models/customer-lifecycle-stage.enum";
+
+export class CustomerAddressDto {
+  @IsOptional()
+  @IsString()
+  id?: string;
+
+  @IsOptional()
+  @IsString()
+  label?: string;
+
+  @IsOptional()
+  @IsString()
+  firstName?: string;
+
+  @IsOptional()
+  @IsString()
+  lastName?: string;
+
+  @IsOptional()
+  @IsString()
+  company?: string;
+
+  @IsString()
+  address1!: string;
+
+  @IsOptional()
+  @IsString()
+  address2?: string;
+
+  @IsString()
+  city!: string;
+
+  @IsOptional()
+  @IsString()
+  postalCode?: string;
+
+  @IsOptional()
+  @IsString()
+  province?: string;
+
+  @IsString()
+  countryCode!: string;
+
+  @IsOptional()
+  @IsString()
+  phone?: string;
+
+  @IsOptional()
+  @IsBoolean()
+  isDefaultShipping?: boolean;
+
+  @IsOptional()
+  @IsBoolean()
+  isDefaultBilling?: boolean;
+}
+
+export class CreateCustomerDto {
+  @IsEmail()
+  email!: string;
+
+  @IsOptional()
+  @IsString()
+  firstName?: string;
+
+  @IsOptional()
+  @IsString()
+  lastName?: string;
+
+  @IsOptional()
+  @IsString()
+  phone?: string;
+
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  tags?: string[];
+
+  @IsOptional()
+  @IsString()
+  notes?: string;
+
+  @IsOptional()
+  @IsEnum(CustomerLifecycleStage)
+  lifecycleStage?: CustomerLifecycleStage;
+
+  @IsOptional()
+  @ValidateNested({ each: true })
+  @Type(() => CustomerAddressDto)
+  addresses?: CustomerAddressDto[];
+
+  @IsOptional()
+  @IsObject()
+  metadata?: Record<string, any>;
+}

--- a/packages/plugin-commerce-api/src/commerce/customers/dto/update-customer.dto.ts
+++ b/packages/plugin-commerce-api/src/commerce/customers/dto/update-customer.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from "@nestjs/mapped-types";
+import { CreateCustomerDto } from "./create-customer.dto";
+
+export class UpdateCustomerDto extends PartialType(CreateCustomerDto) {}

--- a/packages/plugin-commerce-api/src/commerce/customers/index.ts
+++ b/packages/plugin-commerce-api/src/commerce/customers/index.ts
@@ -1,0 +1,18 @@
+/* Models */
+export * from "./models/customer-lifecycle-stage.enum";
+
+/* DTO */
+export * from "./dto/create-customer.dto";
+export * from "./dto/update-customer.dto";
+
+/* Schemas */
+export * from "./schemas/customer.schema";
+
+/* Services */
+export * from "./services/customers.service";
+
+/* Module */
+export * from "./customers.module";
+
+/* Controller */
+export * from "./controllers/customers.controller";

--- a/packages/plugin-commerce-api/src/commerce/customers/models/customer-lifecycle-stage.enum.ts
+++ b/packages/plugin-commerce-api/src/commerce/customers/models/customer-lifecycle-stage.enum.ts
@@ -1,0 +1,7 @@
+export enum CustomerLifecycleStage {
+  Lead = "lead",
+  Prospect = "prospect",
+  Customer = "customer",
+  Loyal = "loyal",
+  Churned = "churned",
+}

--- a/packages/plugin-commerce-api/src/commerce/customers/schemas/customer.schema.ts
+++ b/packages/plugin-commerce-api/src/commerce/customers/schemas/customer.schema.ts
@@ -1,0 +1,106 @@
+import { Prop, Schema, SchemaFactory } from "@nestjs/mongoose";
+import { Document, Schema as SchemaDb, Types } from "mongoose";
+import { CustomerLifecycleStage } from "../models/customer-lifecycle-stage.enum";
+import { COMMERCE_PLUGIN_NAMESPACE } from "../../../constants";
+
+@Schema({ _id: true })
+export class CustomerAddress {
+  @Prop({ type: String })
+  label?: string;
+
+  @Prop({ type: String })
+  firstName?: string;
+
+  @Prop({ type: String })
+  lastName?: string;
+
+  @Prop({ type: String })
+  company?: string;
+
+  @Prop({ type: String, required: true })
+  address1!: string;
+
+  @Prop({ type: String })
+  address2?: string;
+
+  @Prop({ type: String, required: true })
+  city!: string;
+
+  @Prop({ type: String })
+  postalCode?: string;
+
+  @Prop({ type: String })
+  province?: string;
+
+  @Prop({ type: String, required: true })
+  countryCode!: string;
+
+  @Prop({ type: String })
+  phone?: string;
+
+  @Prop({ type: Boolean, default: false })
+  isDefaultShipping!: boolean;
+
+  @Prop({ type: Boolean, default: false })
+  isDefaultBilling!: boolean;
+}
+
+export const CustomerAddressSchema =
+  SchemaFactory.createForClass(CustomerAddress);
+
+@Schema({
+  collection: `${COMMERCE_PLUGIN_NAMESPACE}_customers`,
+  timestamps: true,
+  toJSON: { getters: true },
+})
+export class Customer extends Document {
+  @Prop({ type: String, required: true, unique: true, index: true })
+  email!: string;
+
+  @Prop({ type: String })
+  firstName?: string;
+
+  @Prop({ type: String })
+  lastName?: string;
+
+  @Prop({ type: String })
+  phone?: string;
+
+  @Prop({ type: [String], default: [] })
+  tags!: string[];
+
+  @Prop({ type: String })
+  notes?: string;
+
+  @Prop({
+    type: String,
+    enum: CustomerLifecycleStage,
+    default: CustomerLifecycleStage.Lead,
+  })
+  lifecycleStage!: CustomerLifecycleStage;
+
+  @Prop({ type: [CustomerAddressSchema], default: [] })
+  addresses!: CustomerAddress[];
+
+  @Prop({ type: SchemaDb.ObjectId })
+  defaultShippingAddressId?: Types.ObjectId;
+
+  @Prop({ type: SchemaDb.ObjectId })
+  defaultBillingAddressId?: Types.ObjectId;
+
+  @Prop({ type: Date })
+  lastOrderAt?: Date;
+
+  @Prop({
+    type: SchemaDb.Types.Map,
+    of: SchemaDb.Types.Mixed,
+    default: {},
+  })
+  metadata?: Map<string, any>;
+}
+
+export const CustomerSchema = SchemaFactory.createForClass(Customer);
+
+CustomerSchema.index({ lifecycleStage: 1, createdAt: -1 });
+
+export type CustomerDocument = Customer & Document;

--- a/packages/plugin-commerce-api/src/commerce/customers/services/customers.service.ts
+++ b/packages/plugin-commerce-api/src/commerce/customers/services/customers.service.ts
@@ -1,0 +1,124 @@
+import { Injectable, NotFoundException } from "@nestjs/common";
+import { InjectModel } from "@nestjs/mongoose";
+import { Model, Types } from "mongoose";
+import { Customer, CustomerDocument } from "../schemas/customer.schema";
+import { CreateCustomerDto, CustomerAddressDto } from "../dto/create-customer.dto";
+import { UpdateCustomerDto } from "../dto/update-customer.dto";
+import { CustomerLifecycleStage } from "../models/customer-lifecycle-stage.enum";
+
+type SanitizedAddressesResult = {
+  addresses: (CustomerAddressDto & { _id: Types.ObjectId })[];
+  defaultShipping?: Types.ObjectId;
+  defaultBilling?: Types.ObjectId;
+};
+
+@Injectable()
+export class CustomersService {
+  constructor(
+    @InjectModel(Customer.name)
+    private readonly customerModel: Model<CustomerDocument>
+  ) {}
+
+  private sanitizeAddresses(
+    addresses: CustomerAddressDto[] = []
+  ): SanitizedAddressesResult {
+    const sanitized = addresses.map((address) => ({
+      _id: address.id ? new Types.ObjectId(address.id) : new Types.ObjectId(),
+      label: address.label,
+      firstName: address.firstName,
+      lastName: address.lastName,
+      company: address.company,
+      address1: address.address1,
+      address2: address.address2,
+      city: address.city,
+      postalCode: address.postalCode,
+      province: address.province,
+      countryCode: address.countryCode,
+      phone: address.phone,
+      isDefaultShipping: address.isDefaultShipping ?? false,
+      isDefaultBilling: address.isDefaultBilling ?? false,
+    }));
+
+    let defaultShipping: Types.ObjectId | undefined;
+    let defaultBilling: Types.ObjectId | undefined;
+
+    for (const address of sanitized) {
+      if (address.isDefaultShipping) {
+        if (!defaultShipping) {
+          defaultShipping = address._id;
+        } else {
+          address.isDefaultShipping = false;
+        }
+      }
+      if (address.isDefaultBilling) {
+        if (!defaultBilling) {
+          defaultBilling = address._id;
+        } else {
+          address.isDefaultBilling = false;
+        }
+      }
+    }
+
+    return { addresses: sanitized, defaultShipping, defaultBilling };
+  }
+
+  async create(dto: CreateCustomerDto): Promise<CustomerDocument> {
+    const { addresses, metadata, ...rest } = dto;
+    const sanitizedAddresses = this.sanitizeAddresses(addresses ?? []);
+
+    return this.customerModel.create({
+      ...rest,
+      tags: rest.tags ?? [],
+      lifecycleStage: rest.lifecycleStage ?? CustomerLifecycleStage.Lead,
+      addresses: sanitizedAddresses.addresses,
+      defaultShippingAddressId: sanitizedAddresses.defaultShipping,
+      defaultBillingAddressId: sanitizedAddresses.defaultBilling,
+      metadata: metadata ?? {},
+    });
+  }
+
+  async findAll(): Promise<CustomerDocument[]> {
+    return this.customerModel.find().sort({ createdAt: -1 }).exec();
+  }
+
+  async findOne(id: string): Promise<CustomerDocument> {
+    const customer = await this.customerModel.findById(id).exec();
+    if (!customer) {
+      throw new NotFoundException(`Customer with ID ${id} not found`);
+    }
+    return customer;
+  }
+
+  async update(id: string, dto: UpdateCustomerDto): Promise<CustomerDocument> {
+    const { addresses, metadata, ...rest } = dto;
+    const updateData: Record<string, unknown> = { ...rest };
+
+    if (addresses) {
+      const sanitizedAddresses = this.sanitizeAddresses(addresses);
+      updateData.addresses = sanitizedAddresses.addresses;
+      updateData.defaultShippingAddressId = sanitizedAddresses.defaultShipping;
+      updateData.defaultBillingAddressId = sanitizedAddresses.defaultBilling;
+    }
+
+    if (metadata) {
+      updateData.metadata = metadata;
+    }
+
+    const customer = await this.customerModel
+      .findByIdAndUpdate(id, updateData, { new: true, runValidators: true })
+      .exec();
+
+    if (!customer) {
+      throw new NotFoundException(`Customer with ID ${id} not found`);
+    }
+
+    return customer;
+  }
+
+  async remove(id: string): Promise<void> {
+    const result = await this.customerModel.findByIdAndDelete(id).exec();
+    if (!result) {
+      throw new NotFoundException(`Customer with ID ${id} not found`);
+    }
+  }
+}

--- a/packages/plugin-commerce-api/src/commerce/index.ts
+++ b/packages/plugin-commerce-api/src/commerce/index.ts
@@ -1,0 +1,5 @@
+export * from "./commerce.module";
+export * from "./products";
+export * from "./collections";
+export * from "./customers";
+export * from "./orders";

--- a/packages/plugin-commerce-api/src/commerce/orders/controllers/orders.controller.ts
+++ b/packages/plugin-commerce-api/src/commerce/orders/controllers/orders.controller.ts
@@ -1,0 +1,78 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Patch,
+  Post,
+  UseGuards,
+} from "@nestjs/common";
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+} from "@nestjs/swagger";
+import {
+  JwtAuthGuard,
+  PermissionsGuard,
+  Permissions,
+  ValidateObjectIdPipe,
+} from "@kitejs-cms/core";
+import { OrdersService } from "../services/orders.service";
+import { CreateOrderDto } from "../dto/create-order.dto";
+import { UpdateOrderDto } from "../dto/update-order.dto";
+import { COMMERCE_PLUGIN_NAMESPACE } from "../../../constants";
+
+@ApiTags("Commerce - Orders")
+@ApiBearerAuth()
+@UseGuards(JwtAuthGuard, PermissionsGuard)
+@Controller("commerce/orders")
+export class OrdersController {
+  constructor(private readonly ordersService: OrdersService) {}
+
+  @Post()
+  @Permissions(`${COMMERCE_PLUGIN_NAMESPACE}:orders.create`)
+  @ApiOperation({ summary: "Create a new order" })
+  @ApiResponse({ status: 201, description: "Order created" })
+  create(@Body() dto: CreateOrderDto) {
+    return this.ordersService.create(dto);
+  }
+
+  @Get()
+  @Permissions(`${COMMERCE_PLUGIN_NAMESPACE}:orders.read`)
+  @ApiOperation({ summary: "List orders" })
+  @ApiResponse({ status: 200, description: "List of orders" })
+  findAll() {
+    return this.ordersService.findAll();
+  }
+
+  @Get(":id")
+  @Permissions(`${COMMERCE_PLUGIN_NAMESPACE}:orders.read`)
+  @ApiOperation({ summary: "Retrieve an order" })
+  @ApiResponse({ status: 200, description: "Order detail" })
+  findOne(@Param("id", ValidateObjectIdPipe) id: string) {
+    return this.ordersService.findOne(id);
+  }
+
+  @Patch(":id")
+  @Permissions(`${COMMERCE_PLUGIN_NAMESPACE}:orders.update`)
+  @ApiOperation({ summary: "Update an order" })
+  @ApiResponse({ status: 200, description: "Order updated" })
+  update(
+    @Param("id", ValidateObjectIdPipe) id: string,
+    @Body() dto: UpdateOrderDto
+  ) {
+    return this.ordersService.update(id, dto);
+  }
+
+  @Delete(":id")
+  @Permissions(`${COMMERCE_PLUGIN_NAMESPACE}:orders.delete`)
+  @ApiOperation({ summary: "Delete an order" })
+  @ApiResponse({ status: 204, description: "Order deleted" })
+  async remove(@Param("id", ValidateObjectIdPipe) id: string) {
+    await this.ordersService.remove(id);
+    return { status: "ok" };
+  }
+}

--- a/packages/plugin-commerce-api/src/commerce/orders/dto/create-order.dto.ts
+++ b/packages/plugin-commerce-api/src/commerce/orders/dto/create-order.dto.ts
@@ -1,0 +1,172 @@
+import { Type } from "class-transformer";
+import {
+  IsArray,
+  IsDateString,
+  IsEmail,
+  IsEnum,
+  IsNumber,
+  IsObject,
+  IsOptional,
+  IsString,
+  ValidateNested,
+} from "class-validator";
+import { OrderStatus } from "../models/order-status.enum";
+import { PaymentStatus } from "../models/payment-status.enum";
+import { FulfillmentStatus } from "../models/fulfillment-status.enum";
+
+export class OrderAddressDto {
+  @IsOptional()
+  @IsString()
+  firstName?: string;
+
+  @IsOptional()
+  @IsString()
+  lastName?: string;
+
+  @IsOptional()
+  @IsString()
+  company?: string;
+
+  @IsString()
+  address1!: string;
+
+  @IsOptional()
+  @IsString()
+  address2?: string;
+
+  @IsString()
+  city!: string;
+
+  @IsOptional()
+  @IsString()
+  postalCode?: string;
+
+  @IsOptional()
+  @IsString()
+  province?: string;
+
+  @IsString()
+  countryCode!: string;
+
+  @IsOptional()
+  @IsString()
+  phone?: string;
+}
+
+export class OrderItemDto {
+  @IsString()
+  title!: string;
+
+  @IsOptional()
+  @IsString()
+  variantTitle?: string;
+
+  @Type(() => Number)
+  @IsNumber()
+  quantity!: number;
+
+  @Type(() => Number)
+  @IsNumber()
+  unitPrice!: number;
+
+  @IsString()
+  currencyCode!: string;
+
+  @IsOptional()
+  @IsString()
+  productId?: string;
+
+  @IsOptional()
+  @IsString()
+  variantId?: string;
+
+  @IsOptional()
+  @IsString()
+  sku?: string;
+
+  @IsOptional()
+  @IsObject()
+  metadata?: Record<string, any>;
+}
+
+export class CreateOrderDto {
+  @IsString()
+  orderNumber!: string;
+
+  @IsOptional()
+  @IsEnum(OrderStatus)
+  status?: OrderStatus;
+
+  @IsOptional()
+  @IsEnum(PaymentStatus)
+  paymentStatus?: PaymentStatus;
+
+  @IsOptional()
+  @IsEnum(FulfillmentStatus)
+  fulfillmentStatus?: FulfillmentStatus;
+
+  @IsString()
+  currencyCode!: string;
+
+  @IsOptional()
+  @IsString()
+  customerId?: string;
+
+  @IsOptional()
+  @IsEmail()
+  email?: string;
+
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => OrderAddressDto)
+  billingAddress?: OrderAddressDto;
+
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => OrderAddressDto)
+  shippingAddress?: OrderAddressDto;
+
+  @ValidateNested({ each: true })
+  @Type(() => OrderItemDto)
+  items!: OrderItemDto[];
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
+  shippingTotal?: number;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
+  taxTotal?: number;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
+  discountTotal?: number;
+
+  @IsOptional()
+  @IsString()
+  notes?: string;
+
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  tags?: string[];
+
+  @IsOptional()
+  @IsDateString()
+  paidAt?: string;
+
+  @IsOptional()
+  @IsDateString()
+  fulfilledAt?: string;
+
+  @IsOptional()
+  @IsDateString()
+  cancelledAt?: string;
+
+  @IsOptional()
+  @IsObject()
+  metadata?: Record<string, any>;
+}

--- a/packages/plugin-commerce-api/src/commerce/orders/dto/update-order.dto.ts
+++ b/packages/plugin-commerce-api/src/commerce/orders/dto/update-order.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from "@nestjs/mapped-types";
+import { CreateOrderDto } from "./create-order.dto";
+
+export class UpdateOrderDto extends PartialType(CreateOrderDto) {}

--- a/packages/plugin-commerce-api/src/commerce/orders/index.ts
+++ b/packages/plugin-commerce-api/src/commerce/orders/index.ts
@@ -1,0 +1,20 @@
+/* Models */
+export * from "./models/order-status.enum";
+export * from "./models/payment-status.enum";
+export * from "./models/fulfillment-status.enum";
+
+/* DTO */
+export * from "./dto/create-order.dto";
+export * from "./dto/update-order.dto";
+
+/* Schemas */
+export * from "./schemas/order.schema";
+
+/* Services */
+export * from "./services/orders.service";
+
+/* Module */
+export * from "./orders.module";
+
+/* Controller */
+export * from "./controllers/orders.controller";

--- a/packages/plugin-commerce-api/src/commerce/orders/models/fulfillment-status.enum.ts
+++ b/packages/plugin-commerce-api/src/commerce/orders/models/fulfillment-status.enum.ts
@@ -1,0 +1,7 @@
+export enum FulfillmentStatus {
+  Unfulfilled = "unfulfilled",
+  PartiallyFulfilled = "partially_fulfilled",
+  Fulfilled = "fulfilled",
+  Returned = "returned",
+  Cancelled = "cancelled",
+}

--- a/packages/plugin-commerce-api/src/commerce/orders/models/order-status.enum.ts
+++ b/packages/plugin-commerce-api/src/commerce/orders/models/order-status.enum.ts
@@ -1,0 +1,6 @@
+export enum OrderStatus {
+  Pending = "pending",
+  Processing = "processing",
+  Completed = "completed",
+  Cancelled = "cancelled",
+}

--- a/packages/plugin-commerce-api/src/commerce/orders/models/payment-status.enum.ts
+++ b/packages/plugin-commerce-api/src/commerce/orders/models/payment-status.enum.ts
@@ -1,0 +1,7 @@
+export enum PaymentStatus {
+  Awaiting = "awaiting",
+  Authorized = "authorized",
+  Paid = "paid",
+  PartiallyRefunded = "partially_refunded",
+  Refunded = "refunded",
+}

--- a/packages/plugin-commerce-api/src/commerce/orders/orders.module.ts
+++ b/packages/plugin-commerce-api/src/commerce/orders/orders.module.ts
@@ -1,0 +1,15 @@
+import { Module } from "@nestjs/common";
+import { MongooseModule } from "@nestjs/mongoose";
+import { Order, OrderSchema } from "./schemas/order.schema";
+import { OrdersService } from "./services/orders.service";
+import { OrdersController } from "./controllers/orders.controller";
+
+@Module({
+  imports: [
+    MongooseModule.forFeature([{ name: Order.name, schema: OrderSchema }]),
+  ],
+  controllers: [OrdersController],
+  providers: [OrdersService],
+  exports: [OrdersService],
+})
+export class OrdersModule {}

--- a/packages/plugin-commerce-api/src/commerce/orders/schemas/order.schema.ts
+++ b/packages/plugin-commerce-api/src/commerce/orders/schemas/order.schema.ts
@@ -1,0 +1,165 @@
+import { Prop, Schema, SchemaFactory } from "@nestjs/mongoose";
+import { Document, Schema as SchemaDb, Types } from "mongoose";
+import { OrderStatus } from "../models/order-status.enum";
+import { PaymentStatus } from "../models/payment-status.enum";
+import { FulfillmentStatus } from "../models/fulfillment-status.enum";
+import { COMMERCE_PLUGIN_NAMESPACE } from "../../../constants";
+
+@Schema({ _id: false })
+export class OrderAddress {
+  @Prop({ type: String })
+  firstName?: string;
+
+  @Prop({ type: String })
+  lastName?: string;
+
+  @Prop({ type: String })
+  company?: string;
+
+  @Prop({ type: String, required: true })
+  address1!: string;
+
+  @Prop({ type: String })
+  address2?: string;
+
+  @Prop({ type: String, required: true })
+  city!: string;
+
+  @Prop({ type: String })
+  postalCode?: string;
+
+  @Prop({ type: String })
+  province?: string;
+
+  @Prop({ type: String, required: true })
+  countryCode!: string;
+
+  @Prop({ type: String })
+  phone?: string;
+}
+
+export const OrderAddressSchema = SchemaFactory.createForClass(OrderAddress);
+
+@Schema({ _id: true })
+export class OrderItem {
+  @Prop({ type: String, required: true })
+  title!: string;
+
+  @Prop({ type: String })
+  variantTitle?: string;
+
+  @Prop({ type: Number, required: true })
+  quantity!: number;
+
+  @Prop({ type: Number, required: true })
+  unitPrice!: number;
+
+  @Prop({ type: String, required: true })
+  currencyCode!: string;
+
+  @Prop({ type: SchemaDb.ObjectId, ref: "Product" })
+  productId?: Types.ObjectId;
+
+  @Prop({ type: SchemaDb.ObjectId })
+  variantId?: Types.ObjectId;
+
+  @Prop({ type: String })
+  sku?: string;
+
+  @Prop({
+    type: SchemaDb.Types.Map,
+    of: SchemaDb.Types.Mixed,
+    default: {},
+  })
+  metadata?: Map<string, any>;
+
+  @Prop({ type: Number, required: true })
+  total!: number;
+}
+
+export const OrderItemSchema = SchemaFactory.createForClass(OrderItem);
+
+@Schema({
+  collection: `${COMMERCE_PLUGIN_NAMESPACE}_orders`,
+  timestamps: true,
+  toJSON: { getters: true },
+})
+export class Order extends Document {
+  @Prop({ type: String, required: true, unique: true, index: true })
+  orderNumber!: string;
+
+  @Prop({ type: String, enum: OrderStatus, default: OrderStatus.Pending })
+  status!: OrderStatus;
+
+  @Prop({ type: String, enum: PaymentStatus, default: PaymentStatus.Awaiting })
+  paymentStatus!: PaymentStatus;
+
+  @Prop({
+    type: String,
+    enum: FulfillmentStatus,
+    default: FulfillmentStatus.Unfulfilled,
+  })
+  fulfillmentStatus!: FulfillmentStatus;
+
+  @Prop({ type: String, required: true })
+  currencyCode!: string;
+
+  @Prop({ type: SchemaDb.ObjectId, ref: "Customer" })
+  customer?: Types.ObjectId;
+
+  @Prop({ type: String })
+  email?: string;
+
+  @Prop({ type: [String], default: [] })
+  tags!: string[];
+
+  @Prop({ type: String })
+  notes?: string;
+
+  @Prop({ type: [OrderItemSchema], default: [] })
+  items!: OrderItem[];
+
+  @Prop({ type: Number, default: 0 })
+  subtotal!: number;
+
+  @Prop({ type: Number, default: 0 })
+  shippingTotal!: number;
+
+  @Prop({ type: Number, default: 0 })
+  taxTotal!: number;
+
+  @Prop({ type: Number, default: 0 })
+  discountTotal!: number;
+
+  @Prop({ type: Number, default: 0 })
+  total!: number;
+
+  @Prop({ type: OrderAddressSchema })
+  billingAddress?: OrderAddress;
+
+  @Prop({ type: OrderAddressSchema })
+  shippingAddress?: OrderAddress;
+
+  @Prop({ type: Date })
+  paidAt?: Date;
+
+  @Prop({ type: Date })
+  fulfilledAt?: Date;
+
+  @Prop({ type: Date })
+  cancelledAt?: Date;
+
+  @Prop({
+    type: SchemaDb.Types.Map,
+    of: SchemaDb.Types.Mixed,
+    default: {},
+  })
+  metadata?: Map<string, any>;
+}
+
+export const OrderSchema = SchemaFactory.createForClass(Order);
+
+OrderSchema.index({ status: 1, createdAt: -1 });
+OrderSchema.index({ customer: 1, createdAt: -1 });
+
+export type OrderDocument = Order & Document;

--- a/packages/plugin-commerce-api/src/commerce/orders/services/orders.service.ts
+++ b/packages/plugin-commerce-api/src/commerce/orders/services/orders.service.ts
@@ -1,0 +1,269 @@
+import { Injectable, NotFoundException } from "@nestjs/common";
+import { InjectModel } from "@nestjs/mongoose";
+import { Model, Types } from "mongoose";
+import { Order, OrderDocument } from "../schemas/order.schema";
+import { CreateOrderDto, OrderAddressDto, OrderItemDto } from "../dto/create-order.dto";
+import { UpdateOrderDto } from "../dto/update-order.dto";
+import { OrderStatus } from "../models/order-status.enum";
+import { PaymentStatus } from "../models/payment-status.enum";
+import { FulfillmentStatus } from "../models/fulfillment-status.enum";
+
+type SanitizedItemsResult = {
+  items: Array<
+    Omit<OrderItemDto, "productId" | "variantId" | "metadata"> & {
+      productId?: Types.ObjectId;
+      variantId?: Types.ObjectId;
+      metadata: Record<string, any>;
+      total: number;
+    }
+  >;
+  subtotal: number;
+};
+
+@Injectable()
+export class OrdersService {
+  constructor(
+    @InjectModel(Order.name) private readonly orderModel: Model<OrderDocument>
+  ) {}
+
+  private sanitizeAddress(address?: OrderAddressDto) {
+    if (!address) return undefined;
+    return { ...address };
+  }
+
+  private sanitizeItems(items: OrderItemDto[]): SanitizedItemsResult {
+    const sanitized = items.map((item) => {
+      const quantity = item.quantity;
+      const unitPrice = item.unitPrice;
+      const total = quantity * unitPrice;
+
+      const sanitizedItem: SanitizedItemsResult["items"][number] = {
+        title: item.title,
+        variantTitle: item.variantTitle,
+        quantity,
+        unitPrice,
+        currencyCode: item.currencyCode,
+        sku: item.sku,
+        metadata: item.metadata ?? {},
+        total,
+      };
+
+      if (item.productId) {
+        sanitizedItem.productId = new Types.ObjectId(item.productId);
+      }
+
+      if (item.variantId) {
+        sanitizedItem.variantId = new Types.ObjectId(item.variantId);
+      }
+
+      return sanitizedItem;
+    });
+
+    const subtotal = sanitized.reduce((sum, item) => sum + item.total, 0);
+
+    return { items: sanitized, subtotal };
+  }
+
+  private calculateTotals(
+    subtotal: number,
+    shippingTotal?: number,
+    taxTotal?: number,
+    discountTotal?: number
+  ) {
+    const shipping = shippingTotal ?? 0;
+    const tax = taxTotal ?? 0;
+    const discount = discountTotal ?? 0;
+    const total = Math.max(subtotal + shipping + tax - discount, 0);
+
+    return {
+      subtotal,
+      shippingTotal: shipping,
+      taxTotal: tax,
+      discountTotal: discount,
+      total,
+    };
+  }
+
+  private toDate(value?: string) {
+    return value ? new Date(value) : undefined;
+  }
+
+  async create(dto: CreateOrderDto): Promise<OrderDocument> {
+    const {
+      customerId,
+      billingAddress,
+      shippingAddress,
+      items,
+      metadata,
+      paidAt,
+      fulfilledAt,
+      cancelledAt,
+      ...rest
+    } = dto;
+
+    const sanitizedItems = this.sanitizeItems(items);
+    const totals = this.calculateTotals(
+      sanitizedItems.subtotal,
+      dto.shippingTotal,
+      dto.taxTotal,
+      dto.discountTotal
+    );
+
+    return this.orderModel.create({
+      ...rest,
+      status: rest.status ?? OrderStatus.Pending,
+      paymentStatus: rest.paymentStatus ?? PaymentStatus.Awaiting,
+      fulfillmentStatus:
+        rest.fulfillmentStatus ?? FulfillmentStatus.Unfulfilled,
+      customer: customerId ? new Types.ObjectId(customerId) : undefined,
+      items: sanitizedItems.items,
+      subtotal: totals.subtotal,
+      shippingTotal: totals.shippingTotal,
+      taxTotal: totals.taxTotal,
+      discountTotal: totals.discountTotal,
+      total: totals.total,
+      billingAddress: this.sanitizeAddress(billingAddress),
+      shippingAddress: this.sanitizeAddress(shippingAddress),
+      metadata: metadata ?? {},
+      tags: rest.tags ?? [],
+      paidAt: this.toDate(paidAt),
+      fulfilledAt: this.toDate(fulfilledAt),
+      cancelledAt: this.toDate(cancelledAt),
+    });
+  }
+
+  async findAll(): Promise<OrderDocument[]> {
+    return this.orderModel.find().sort({ createdAt: -1 }).populate("customer").exec();
+  }
+
+  async findOne(id: string): Promise<OrderDocument> {
+    const order = await this.orderModel
+      .findById(id)
+      .populate("customer")
+      .exec();
+
+    if (!order) {
+      throw new NotFoundException(`Order with ID ${id} not found`);
+    }
+
+    return order;
+  }
+
+  async update(id: string, dto: UpdateOrderDto): Promise<OrderDocument> {
+    const {
+      customerId,
+      billingAddress,
+      shippingAddress,
+      items,
+      metadata,
+      paidAt,
+      fulfilledAt,
+      cancelledAt,
+      ...rest
+    } = dto;
+
+    const updateData: Record<string, unknown> = {
+      ...rest,
+    };
+
+    if (customerId !== undefined) {
+      updateData.customer = customerId
+        ? new Types.ObjectId(customerId)
+        : null;
+    }
+
+    if (billingAddress !== undefined) {
+      updateData.billingAddress = this.sanitizeAddress(billingAddress);
+    }
+
+    if (shippingAddress !== undefined) {
+      updateData.shippingAddress = this.sanitizeAddress(shippingAddress);
+    }
+
+    let subtotalFromItems: number | undefined;
+
+    if (items) {
+      const sanitizedItems = this.sanitizeItems(items);
+      updateData.items = sanitizedItems.items;
+      subtotalFromItems = sanitizedItems.subtotal;
+    }
+
+    if (metadata) {
+      updateData.metadata = metadata;
+    }
+
+    if (paidAt !== undefined) {
+      updateData.paidAt = paidAt ? new Date(paidAt) : null;
+    }
+
+    if (fulfilledAt !== undefined) {
+      updateData.fulfilledAt = fulfilledAt ? new Date(fulfilledAt) : null;
+    }
+
+    if (cancelledAt !== undefined) {
+      updateData.cancelledAt = cancelledAt ? new Date(cancelledAt) : null;
+    }
+
+    const shouldRecalculateTotals =
+      items !== undefined ||
+      dto.shippingTotal !== undefined ||
+      dto.taxTotal !== undefined ||
+      dto.discountTotal !== undefined;
+
+    if (shouldRecalculateTotals) {
+      const existing =
+        items !== undefined
+          ? undefined
+          : await this.orderModel
+              .findById(id)
+              .select("subtotal shippingTotal taxTotal discountTotal")
+              .lean();
+
+      const baseSubtotal =
+        subtotalFromItems !== undefined
+          ? subtotalFromItems
+          : existing?.subtotal ?? 0;
+      const shippingTotal =
+        dto.shippingTotal !== undefined
+          ? dto.shippingTotal
+          : existing?.shippingTotal ?? 0;
+      const taxTotal =
+        dto.taxTotal !== undefined ? dto.taxTotal : existing?.taxTotal ?? 0;
+      const discountTotal =
+        dto.discountTotal !== undefined
+          ? dto.discountTotal
+          : existing?.discountTotal ?? 0;
+
+      const totals = this.calculateTotals(
+        baseSubtotal,
+        shippingTotal,
+        taxTotal,
+        discountTotal
+      );
+
+      updateData.subtotal = totals.subtotal;
+      updateData.shippingTotal = totals.shippingTotal;
+      updateData.taxTotal = totals.taxTotal;
+      updateData.discountTotal = totals.discountTotal;
+      updateData.total = totals.total;
+    }
+
+    const order = await this.orderModel
+      .findByIdAndUpdate(id, updateData, { new: true, runValidators: true })
+      .populate("customer")
+      .exec();
+
+    if (!order) {
+      throw new NotFoundException(`Order with ID ${id} not found`);
+    }
+
+    return order;
+  }
+
+  async remove(id: string): Promise<void> {
+    const result = await this.orderModel.findByIdAndDelete(id).exec();
+    if (!result) {
+      throw new NotFoundException(`Order with ID ${id} not found`);
+    }
+  }
+}

--- a/packages/plugin-commerce-api/src/commerce/products/controllers/products.controller.ts
+++ b/packages/plugin-commerce-api/src/commerce/products/controllers/products.controller.ts
@@ -1,0 +1,78 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Patch,
+  Post,
+  UseGuards,
+} from "@nestjs/common";
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+} from "@nestjs/swagger";
+import {
+  JwtAuthGuard,
+  PermissionsGuard,
+  Permissions,
+  ValidateObjectIdPipe,
+} from "@kitejs-cms/core";
+import { ProductsService } from "../services/products.service";
+import { CreateProductDto } from "../dto/create-product.dto";
+import { UpdateProductDto } from "../dto/update-product.dto";
+import { COMMERCE_PLUGIN_NAMESPACE } from "../../../constants";
+
+@ApiTags("Commerce - Products")
+@ApiBearerAuth()
+@UseGuards(JwtAuthGuard, PermissionsGuard)
+@Controller("commerce/products")
+export class ProductsController {
+  constructor(private readonly productsService: ProductsService) {}
+
+  @Post()
+  @Permissions(`${COMMERCE_PLUGIN_NAMESPACE}:products.create`)
+  @ApiOperation({ summary: "Create a new product" })
+  @ApiResponse({ status: 201, description: "Product created" })
+  create(@Body() dto: CreateProductDto) {
+    return this.productsService.create(dto);
+  }
+
+  @Get()
+  @Permissions(`${COMMERCE_PLUGIN_NAMESPACE}:products.read`)
+  @ApiOperation({ summary: "List products" })
+  @ApiResponse({ status: 200, description: "List of products" })
+  findAll() {
+    return this.productsService.findAll();
+  }
+
+  @Get(":id")
+  @Permissions(`${COMMERCE_PLUGIN_NAMESPACE}:products.read`)
+  @ApiOperation({ summary: "Retrieve a product by id" })
+  @ApiResponse({ status: 200, description: "Product detail" })
+  findOne(@Param("id", ValidateObjectIdPipe) id: string) {
+    return this.productsService.findOne(id);
+  }
+
+  @Patch(":id")
+  @Permissions(`${COMMERCE_PLUGIN_NAMESPACE}:products.update`)
+  @ApiOperation({ summary: "Update a product" })
+  @ApiResponse({ status: 200, description: "Product updated" })
+  update(
+    @Param("id", ValidateObjectIdPipe) id: string,
+    @Body() dto: UpdateProductDto
+  ) {
+    return this.productsService.update(id, dto);
+  }
+
+  @Delete(":id")
+  @Permissions(`${COMMERCE_PLUGIN_NAMESPACE}:products.delete`)
+  @ApiOperation({ summary: "Delete a product" })
+  @ApiResponse({ status: 204, description: "Product deleted" })
+  async remove(@Param("id", ValidateObjectIdPipe) id: string) {
+    await this.productsService.remove(id);
+    return { status: "ok" };
+  }
+}

--- a/packages/plugin-commerce-api/src/commerce/products/dto/create-product.dto.ts
+++ b/packages/plugin-commerce-api/src/commerce/products/dto/create-product.dto.ts
@@ -1,0 +1,181 @@
+import { Type } from "class-transformer";
+import {
+  IsArray,
+  IsBoolean,
+  IsDateString,
+  IsEnum,
+  IsNumber,
+  IsObject,
+  IsOptional,
+  IsString,
+  ValidateNested,
+} from "class-validator";
+import { InventoryPolicy } from "../models/inventory-policy.enum";
+import { ProductStatus } from "../models/product-status.enum";
+
+export class MoneyAmountDto {
+  @IsString()
+  currencyCode!: string;
+
+  @Type(() => Number)
+  @IsNumber()
+  amount!: number;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
+  compareAtAmount?: number;
+}
+
+export class ProductOptionDto {
+  @IsString()
+  name!: string;
+
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  values?: string[];
+}
+
+export class ProductVariantOptionDto {
+  @IsString()
+  name!: string;
+
+  @IsString()
+  value!: string;
+}
+
+export class DimensionsDto {
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
+  length?: number;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
+  width?: number;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
+  height?: number;
+}
+
+export class ProductVariantDto {
+  @IsString()
+  title!: string;
+
+  @IsString()
+  sku!: string;
+
+  @IsOptional()
+  @IsString()
+  barcode?: string;
+
+  @IsOptional()
+  @ValidateNested({ each: true })
+  @Type(() => MoneyAmountDto)
+  prices?: MoneyAmountDto[];
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
+  inventoryQuantity?: number;
+
+  @IsOptional()
+  @IsEnum(InventoryPolicy)
+  inventoryPolicy?: InventoryPolicy;
+
+  @IsOptional()
+  @IsBoolean()
+  manageInventory?: boolean;
+
+  @IsOptional()
+  @IsBoolean()
+  allowBackorder?: boolean;
+
+  @IsOptional()
+  @ValidateNested({ each: true })
+  @Type(() => ProductVariantOptionDto)
+  options?: ProductVariantOptionDto[];
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
+  weight?: number;
+
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => DimensionsDto)
+  dimensions?: DimensionsDto;
+
+  @IsOptional()
+  @IsObject()
+  metadata?: Record<string, any>;
+}
+
+export class CreateProductDto {
+  @IsString()
+  title!: string;
+
+  @IsString()
+  handle!: string;
+
+  @IsOptional()
+  @IsString()
+  subtitle?: string;
+
+  @IsOptional()
+  @IsString()
+  description?: string;
+
+  @IsOptional()
+  @IsEnum(ProductStatus)
+  status?: ProductStatus;
+
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  tags?: string[];
+
+  @IsOptional()
+  @IsString()
+  thumbnail?: string;
+
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  collectionIds?: string[];
+
+  @IsOptional()
+  @ValidateNested({ each: true })
+  @Type(() => ProductOptionDto)
+  options?: ProductOptionDto[];
+
+  @ValidateNested({ each: true })
+  @Type(() => ProductVariantDto)
+  variants!: ProductVariantDto[];
+
+  @IsOptional()
+  @ValidateNested({ each: true })
+  @Type(() => MoneyAmountDto)
+  pricing?: MoneyAmountDto[];
+
+  @IsOptional()
+  @IsBoolean()
+  isGiftCard?: boolean;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
+  weight?: number;
+
+  @IsOptional()
+  @IsDateString()
+  publishedAt?: string;
+
+  @IsOptional()
+  @IsObject()
+  metadata?: Record<string, any>;
+}

--- a/packages/plugin-commerce-api/src/commerce/products/dto/update-product.dto.ts
+++ b/packages/plugin-commerce-api/src/commerce/products/dto/update-product.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from "@nestjs/mapped-types";
+import { CreateProductDto } from "./create-product.dto";
+
+export class UpdateProductDto extends PartialType(CreateProductDto) {}

--- a/packages/plugin-commerce-api/src/commerce/products/index.ts
+++ b/packages/plugin-commerce-api/src/commerce/products/index.ts
@@ -1,0 +1,19 @@
+/* Models */
+export * from "./models/product-status.enum";
+export * from "./models/inventory-policy.enum";
+
+/* DTO */
+export * from "./dto/create-product.dto";
+export * from "./dto/update-product.dto";
+
+/* Schemas */
+export * from "./schemas/product.schema";
+
+/* Services */
+export * from "./services/products.service";
+
+/* Module */
+export * from "./products.module";
+
+/* Controller */
+export * from "./controllers/products.controller";

--- a/packages/plugin-commerce-api/src/commerce/products/models/inventory-policy.enum.ts
+++ b/packages/plugin-commerce-api/src/commerce/products/models/inventory-policy.enum.ts
@@ -1,0 +1,4 @@
+export enum InventoryPolicy {
+  Deny = "deny",
+  Allow = "allow",
+}

--- a/packages/plugin-commerce-api/src/commerce/products/models/product-status.enum.ts
+++ b/packages/plugin-commerce-api/src/commerce/products/models/product-status.enum.ts
@@ -1,0 +1,5 @@
+export enum ProductStatus {
+  Draft = "draft",
+  Active = "active",
+  Archived = "archived",
+}

--- a/packages/plugin-commerce-api/src/commerce/products/products.module.ts
+++ b/packages/plugin-commerce-api/src/commerce/products/products.module.ts
@@ -1,0 +1,15 @@
+import { Module } from "@nestjs/common";
+import { MongooseModule } from "@nestjs/mongoose";
+import { Product, ProductSchema } from "./schemas/product.schema";
+import { ProductsService } from "./services/products.service";
+import { ProductsController } from "./controllers/products.controller";
+
+@Module({
+  imports: [
+    MongooseModule.forFeature([{ name: Product.name, schema: ProductSchema }]),
+  ],
+  controllers: [ProductsController],
+  providers: [ProductsService],
+  exports: [ProductsService],
+})
+export class ProductsModule {}

--- a/packages/plugin-commerce-api/src/commerce/products/schemas/product.schema.ts
+++ b/packages/plugin-commerce-api/src/commerce/products/schemas/product.schema.ts
@@ -1,0 +1,172 @@
+import { Prop, Schema, SchemaFactory } from "@nestjs/mongoose";
+import { Document, Schema as SchemaDb, Types } from "mongoose";
+import { InventoryPolicy } from "../models/inventory-policy.enum";
+import { ProductStatus } from "../models/product-status.enum";
+import { COMMERCE_PLUGIN_NAMESPACE } from "../../../constants";
+
+@Schema({ _id: false })
+export class MoneyAmount {
+  @Prop({ type: String, required: true })
+  currencyCode!: string;
+
+  @Prop({ type: Number, required: true })
+  amount!: number;
+
+  @Prop({ type: Number })
+  compareAtAmount?: number;
+}
+
+export const MoneyAmountSchema = SchemaFactory.createForClass(MoneyAmount);
+
+@Schema({ _id: false })
+export class ProductVariantOption {
+  @Prop({ type: String, required: true })
+  name!: string;
+
+  @Prop({ type: String, required: true })
+  value!: string;
+}
+
+export const ProductVariantOptionSchema =
+  SchemaFactory.createForClass(ProductVariantOption);
+
+@Schema({ _id: false })
+export class Dimensions {
+  @Prop({ type: Number })
+  length?: number;
+
+  @Prop({ type: Number })
+  width?: number;
+
+  @Prop({ type: Number })
+  height?: number;
+}
+
+export const DimensionsSchema = SchemaFactory.createForClass(Dimensions);
+
+@Schema({ _id: false })
+export class ProductOption {
+  @Prop({ type: String, required: true })
+  name!: string;
+
+  @Prop({ type: [String], default: [] })
+  values!: string[];
+}
+
+export const ProductOptionSchema = SchemaFactory.createForClass(ProductOption);
+
+@Schema({ _id: true, timestamps: false })
+export class ProductVariant {
+  @Prop({ type: String, required: true })
+  title!: string;
+
+  @Prop({ type: String, required: true })
+  sku!: string;
+
+  @Prop({ type: String })
+  barcode?: string;
+
+  @Prop({ type: [MoneyAmountSchema], default: [] })
+  prices!: MoneyAmount[];
+
+  @Prop({ type: Number, default: 0 })
+  inventoryQuantity!: number;
+
+  @Prop({
+    type: String,
+    enum: InventoryPolicy,
+    default: InventoryPolicy.Deny,
+  })
+  inventoryPolicy!: InventoryPolicy;
+
+  @Prop({ type: Boolean, default: true })
+  manageInventory!: boolean;
+
+  @Prop({ type: Boolean, default: false })
+  allowBackorder!: boolean;
+
+  @Prop({ type: [ProductVariantOptionSchema], default: [] })
+  options!: ProductVariantOption[];
+
+  @Prop({ type: Number })
+  weight?: number;
+
+  @Prop({ type: DimensionsSchema })
+  dimensions?: Dimensions;
+
+  @Prop({
+    type: SchemaDb.Types.Map,
+    of: SchemaDb.Types.Mixed,
+    default: {},
+  })
+  metadata?: Map<string, any>;
+}
+
+export const ProductVariantSchema = SchemaFactory.createForClass(ProductVariant);
+
+@Schema({
+  collection: `${COMMERCE_PLUGIN_NAMESPACE}_products`,
+  timestamps: true,
+  toJSON: { getters: true },
+})
+export class Product extends Document {
+  @Prop({ type: String, required: true })
+  title!: string;
+
+  @Prop({ type: String, required: true, unique: true, index: true })
+  handle!: string;
+
+  @Prop({ type: String })
+  subtitle?: string;
+
+  @Prop({ type: String })
+  description?: string;
+
+  @Prop({ type: String, enum: ProductStatus, default: ProductStatus.Draft })
+  status!: ProductStatus;
+
+  @Prop({ type: [String], default: [] })
+  tags!: string[];
+
+  @Prop({ type: String })
+  thumbnail?: string;
+
+  @Prop({
+    type: [SchemaDb.ObjectId],
+    ref: "ProductCollection",
+    default: [],
+  })
+  collections!: Types.ObjectId[];
+
+  @Prop({ type: [ProductOptionSchema], default: [] })
+  options!: ProductOption[];
+
+  @Prop({ type: [ProductVariantSchema], default: [] })
+  variants!: ProductVariant[];
+
+  @Prop({ type: [MoneyAmountSchema], default: [] })
+  pricing!: MoneyAmount[];
+
+  @Prop({ type: Boolean, default: false })
+  isGiftCard!: boolean;
+
+  @Prop({ type: Number })
+  weight?: number;
+
+  @Prop({ type: Date })
+  publishedAt?: Date;
+
+  @Prop({
+    type: SchemaDb.Types.Map,
+    of: SchemaDb.Types.Mixed,
+    default: {},
+  })
+  metadata?: Map<string, any>;
+}
+
+export const ProductSchema = SchemaFactory.createForClass(Product);
+
+ProductSchema.index({ status: 1, updatedAt: -1 });
+ProductSchema.index({ tags: 1 });
+
+export type ProductDocument = Product & Document;

--- a/packages/plugin-commerce-api/src/commerce/products/services/products.service.ts
+++ b/packages/plugin-commerce-api/src/commerce/products/services/products.service.ts
@@ -1,0 +1,138 @@
+import { Injectable, NotFoundException } from "@nestjs/common";
+import { InjectModel } from "@nestjs/mongoose";
+import { Model, Types } from "mongoose";
+import { Product, ProductDocument } from "../schemas/product.schema";
+import { CreateProductDto, ProductVariantDto } from "../dto/create-product.dto";
+import { UpdateProductDto } from "../dto/update-product.dto";
+import { ProductStatus } from "../models/product-status.enum";
+
+@Injectable()
+export class ProductsService {
+  constructor(
+    @InjectModel(Product.name) private readonly productModel: Model<ProductDocument>
+  ) {}
+
+  private mapCollectionIds(collectionIds?: string[]): Types.ObjectId[] | undefined {
+    if (!collectionIds) return undefined;
+    return collectionIds
+      .filter((id) => !!id)
+      .map((id) => new Types.ObjectId(id));
+  }
+
+  private sanitizeVariants(variants: ProductVariantDto[]) {
+    return variants.map((variant) => ({
+      ...variant,
+      prices: variant.prices?.map((price) => ({ ...price })) ?? [],
+      options: variant.options?.map((option) => ({ ...option })) ?? [],
+      metadata: variant.metadata ?? {},
+    }));
+  }
+
+  async create(dto: CreateProductDto): Promise<ProductDocument> {
+    const {
+      collectionIds,
+      publishedAt,
+      variants,
+      options,
+      pricing,
+      metadata,
+      ...rest
+    } = dto;
+
+    const product = await this.productModel.create({
+      ...rest,
+      status: rest.status ?? ProductStatus.Draft,
+      tags: rest.tags ?? [],
+      collections: this.mapCollectionIds(collectionIds) ?? [],
+      variants: this.sanitizeVariants(variants),
+      options: options?.map((option) => ({ ...option })) ?? [],
+      pricing: pricing?.map((price) => ({ ...price })) ?? [],
+      metadata: metadata ?? {},
+      publishedAt: publishedAt ? new Date(publishedAt) : undefined,
+    });
+
+    return product;
+  }
+
+  async findAll(): Promise<ProductDocument[]> {
+    return this.productModel
+      .find()
+      .populate("collections")
+      .sort({ createdAt: -1 })
+      .exec();
+  }
+
+  async findOne(id: string): Promise<ProductDocument> {
+    const product = await this.productModel
+      .findById(id)
+      .populate("collections")
+      .exec();
+
+    if (!product) {
+      throw new NotFoundException(`Product with ID ${id} not found`);
+    }
+
+    return product;
+  }
+
+  async update(id: string, dto: UpdateProductDto): Promise<ProductDocument> {
+    const {
+      collectionIds,
+      publishedAt,
+      variants,
+      options,
+      pricing,
+      metadata,
+      ...rest
+    } = dto;
+
+    const updateData: Record<string, unknown> = {
+      ...rest,
+    };
+
+    if (collectionIds) {
+      updateData.collections = this.mapCollectionIds(collectionIds);
+    }
+
+    if (variants) {
+      updateData.variants = this.sanitizeVariants(variants);
+    }
+
+    if (options) {
+      updateData.options = options.map((option) => ({ ...option }));
+    }
+
+    if (pricing) {
+      updateData.pricing = pricing.map((price) => ({ ...price }));
+    }
+
+    if (metadata) {
+      updateData.metadata = metadata;
+    }
+
+    if (publishedAt !== undefined) {
+      updateData.publishedAt = publishedAt ? new Date(publishedAt) : null;
+    }
+
+    const product = await this.productModel
+      .findByIdAndUpdate(id, updateData, {
+        new: true,
+        runValidators: true,
+      })
+      .populate("collections")
+      .exec();
+
+    if (!product) {
+      throw new NotFoundException(`Product with ID ${id} not found`);
+    }
+
+    return product;
+  }
+
+  async remove(id: string): Promise<void> {
+    const result = await this.productModel.findByIdAndDelete(id).exec();
+    if (!result) {
+      throw new NotFoundException(`Product with ID ${id} not found`);
+    }
+  }
+}

--- a/packages/plugin-commerce-api/src/constants.ts
+++ b/packages/plugin-commerce-api/src/constants.ts
@@ -1,0 +1,114 @@
+import {
+  FieldDefinition,
+  PermissionModel,
+  SettingModel,
+} from "@kitejs-cms/core";
+
+export const COMMERCE_PLUGIN_NAMESPACE = "commerce-plugin";
+export const COMMERCE_PRODUCT_SLUG_NAMESPACE = `${COMMERCE_PLUGIN_NAMESPACE}:products`;
+
+export const CommercePermissions: PermissionModel[] = [
+  {
+    name: `${COMMERCE_PLUGIN_NAMESPACE}:products.read`,
+    description: "Permission to view products",
+    role: ["admin", "editor", "viewer"],
+  },
+  {
+    name: `${COMMERCE_PLUGIN_NAMESPACE}:products.create`,
+    description: "Permission to create products",
+    role: ["admin", "editor"],
+  },
+  {
+    name: `${COMMERCE_PLUGIN_NAMESPACE}:products.update`,
+    description: "Permission to update products",
+    role: ["admin", "editor"],
+  },
+  {
+    name: `${COMMERCE_PLUGIN_NAMESPACE}:products.delete`,
+    description: "Permission to delete products",
+    role: ["admin"],
+  },
+  {
+    name: `${COMMERCE_PLUGIN_NAMESPACE}:collections.read`,
+    description: "Permission to view product collections",
+    role: ["admin", "editor", "viewer"],
+  },
+  {
+    name: `${COMMERCE_PLUGIN_NAMESPACE}:collections.create`,
+    description: "Permission to create product collections",
+    role: ["admin", "editor"],
+  },
+  {
+    name: `${COMMERCE_PLUGIN_NAMESPACE}:collections.update`,
+    description: "Permission to update product collections",
+    role: ["admin", "editor"],
+  },
+  {
+    name: `${COMMERCE_PLUGIN_NAMESPACE}:collections.delete`,
+    description: "Permission to delete product collections",
+    role: ["admin"],
+  },
+  {
+    name: `${COMMERCE_PLUGIN_NAMESPACE}:customers.read`,
+    description: "Permission to view customers",
+    role: ["admin", "editor", "viewer"],
+  },
+  {
+    name: `${COMMERCE_PLUGIN_NAMESPACE}:customers.create`,
+    description: "Permission to create customers",
+    role: ["admin", "editor"],
+  },
+  {
+    name: `${COMMERCE_PLUGIN_NAMESPACE}:customers.update`,
+    description: "Permission to update customers",
+    role: ["admin", "editor"],
+  },
+  {
+    name: `${COMMERCE_PLUGIN_NAMESPACE}:customers.delete`,
+    description: "Permission to delete customers",
+    role: ["admin"],
+  },
+  {
+    name: `${COMMERCE_PLUGIN_NAMESPACE}:orders.read`,
+    description: "Permission to view orders",
+    role: ["admin", "editor", "viewer"],
+  },
+  {
+    name: `${COMMERCE_PLUGIN_NAMESPACE}:orders.create`,
+    description: "Permission to create orders",
+    role: ["admin", "editor"],
+  },
+  {
+    name: `${COMMERCE_PLUGIN_NAMESPACE}:orders.update`,
+    description: "Permission to update orders",
+    role: ["admin", "editor"],
+  },
+  {
+    name: `${COMMERCE_PLUGIN_NAMESPACE}:orders.delete`,
+    description: "Permission to delete orders",
+    role: ["admin"],
+  },
+];
+
+export const COMMERCE_SETTINGS_KEY = `${COMMERCE_PLUGIN_NAMESPACE}:settings`;
+
+export type CommercePluginSettingsModel = {
+  defaultCurrency: string;
+  allowGuestCheckout: boolean;
+  taxInclusivePricing: boolean;
+  customProductFields?: FieldDefinition[];
+  customCustomerFields?: FieldDefinition[];
+};
+
+export const CommerceSetting: SettingModel<CommercePluginSettingsModel>[] = [
+  {
+    key: COMMERCE_SETTINGS_KEY,
+    value: {
+      defaultCurrency: "EUR",
+      allowGuestCheckout: true,
+      taxInclusivePricing: false,
+      customProductFields: [],
+      customCustomerFields: [],
+    },
+  },
+];

--- a/packages/plugin-commerce-api/src/index.ts
+++ b/packages/plugin-commerce-api/src/index.ts
@@ -1,0 +1,4 @@
+export * from "./commerce-plugin.module";
+export * from "./commerce";
+export * from "./plugin.config";
+export * from "./constants";

--- a/packages/plugin-commerce-api/src/plugin.config.ts
+++ b/packages/plugin-commerce-api/src/plugin.config.ts
@@ -1,0 +1,28 @@
+import { Logger } from "@nestjs/common";
+import {
+  COMMERCE_PLUGIN_NAMESPACE,
+  CommercePermissions,
+  CommerceSetting,
+} from "./constants";
+import { CommercePluginModule } from "./commerce-plugin.module";
+import { IPlugin } from "@kitejs-cms/core";
+import { version } from "../package.json";
+
+const logger = new Logger("CommercePluginConfig");
+
+export const CommercePlugin: IPlugin = {
+  namespace: COMMERCE_PLUGIN_NAMESPACE,
+  name: "Commerce Plugin",
+  version,
+  description:
+    "Plugin that provides foundational commerce APIs for products, orders and customers.",
+  enabled: true,
+  settings: CommerceSetting,
+  permissions: CommercePermissions,
+  initialize: async () => {
+    logger.log("Initializing commerce plugin");
+  },
+  getModule: () => {
+    return CommercePluginModule;
+  },
+};

--- a/packages/plugin-commerce-api/tsconfig.json
+++ b/packages/plugin-commerce-api/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "@kitejs-cms/typescript-config/nestjs.json",
+  "compilerOptions": {
+    "allowJs": true,
+    "baseUrl": "src",
+    "rootDir": "src",
+    "esModuleInterop": true,
+    "incremental": false,
+    "outDir": "dist",
+    "declaration": true,
+    "module": "nodenext",
+    "moduleResolution": "nodenext"
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "test", "dist", "**/*spec.ts"]
+}


### PR DESCRIPTION
## Summary
- add a new `@kitejs-cms/plugin-commerce-api` workspace package with build tooling and plugin registration metadata
- scaffold commerce domain modules for products, collections, customers, and orders with Nest controllers, services, DTOs, and Mongoose schemas
- implement persistence models including product variants, customer addresses, and order line calculations to support advanced commerce use cases

## Testing
- `pnpm install --filter @kitejs-cms/plugin-commerce-api...` *(fails: registry returned 403 so dependencies could not be installed)*
- `pnpm lint --filter @kitejs-cms/plugin-commerce-api` *(fails: missing workspace dependencies because install could not complete)*

------
https://chatgpt.com/codex/tasks/task_e_68c9954d5738832898950bf6b27633de