### PR TITLE
feat: add commerce dashboard plugin

### DIFF
--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -12,6 +12,7 @@
     "@kitejs-cms/dashboard-core": "workspace:*",
     "@kitejs-cms/plugin-gallery-dashboard": "workspace:*",
     "@kitejs-cms/plugin-analytics-dashboard": "workspace:*",
+    "@kitejs-cms/plugin-commerce-dashboard": "workspace:*",
     "@tailwindcss/vite": "^4.0.8",
     "install": "^0.13.0",
     "react": "^19.0.0",

--- a/apps/dashboard/src/main.tsx
+++ b/apps/dashboard/src/main.tsx
@@ -2,11 +2,14 @@ import { createRoot } from "react-dom/client";
 import { DashboardProvider } from "@kitejs-cms/dashboard-core/dashboard-provider";
 import { GalleryModule } from "@kitejs-cms/plugin-gallery-dashboard";
 import { AnalyticsModule } from "@kitejs-cms/plugin-analytics-dashboard";
+import { CommerceModule } from "@kitejs-cms/plugin-commerce-dashboard";
 
 /* CSS */
 import "./index.css";
 import "@kitejs-cms/dashboard-core/styles.css";
 
 createRoot(document.getElementById("root")!).render(
-  <DashboardProvider modules={[GalleryModule, AnalyticsModule]} />
+  <DashboardProvider
+    modules={[GalleryModule, AnalyticsModule, CommerceModule]}
+  />
 );

--- a/packages/plugin-analytics-dashboard/package.json
+++ b/packages/plugin-analytics-dashboard/package.json
@@ -37,8 +37,8 @@
   "peerDependencies": {
     "@kitejs-cms/dashboard-core": "workspace:*",
     "date-fns": "^4.1.0",
-    "react": "^18.2.0 || ^19.0.0",
-    "react-dom": "^18.2.0 || ^19.0.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
     "react-i18next": "^15.4.1",
     "react-router-dom": "^7.8.2"
   },

--- a/packages/plugin-commerce-dashboard/eslint.config.mjs
+++ b/packages/plugin-commerce-dashboard/eslint.config.mjs
@@ -1,0 +1,4 @@
+import { config } from "../eslint-config/react-internal.js";
+
+/** @type {import("eslint").Linter.Config} */
+export default config;

--- a/packages/plugin-commerce-dashboard/package.json
+++ b/packages/plugin-commerce-dashboard/package.json
@@ -36,8 +36,8 @@
   },
   "peerDependencies": {
     "@kitejs-cms/dashboard-core": "workspace:*",
-    "react": "^18.2.0 || ^19.0.0",
-    "react-dom": "^18.2.0 || ^19.0.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
     "react-i18next": "^15.4.1",
     "react-router-dom": "^7.2.0"
   },

--- a/packages/plugin-commerce-dashboard/package.json
+++ b/packages/plugin-commerce-dashboard/package.json
@@ -1,0 +1,58 @@
+{
+  "name": "@kitejs-cms/plugin-commerce-dashboard",
+  "version": "0.0.1-alpha.6",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "sideEffects": [
+    "**/*.css"
+  ],
+  "files": [
+    "dist"
+  ],
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "./styles.css": "./dist/styles.css",
+    "./*": {
+      "import": "./dist/*.js",
+      "require": "./dist/*.js",
+      "types": "./dist/*.d.ts"
+    }
+  },
+  "scripts": {
+    "build:ts": "tsc -b",
+    "build:css": "tailwindcss -i ./src/styles.css -o ./dist/styles.css",
+    "build": "pnpm run build:ts && pnpm run build:css",
+    "dev": "pnpm run dev:ts & pnpm run dev:css",
+    "dev:ts": "tsc -b --watch",
+    "dev:css": "tailwindcss -i ./src/styles.css -o ./dist/styles.css --watch",
+    "check-types": "tsc --noEmit",
+    "lint": "eslint src --ext .ts,.tsx --max-warnings 0",
+    "prepublishOnly": "pnpm run build"
+  },
+  "peerDependencies": {
+    "@kitejs-cms/dashboard-core": "workspace:*",
+    "react": "^18.2.0 || ^19.0.0",
+    "react-dom": "^18.2.0 || ^19.0.0",
+    "react-i18next": "^15.4.1",
+    "react-router-dom": "^7.2.0"
+  },
+  "dependencies": {
+    "lucide-react": "^0.475.0"
+  },
+  "devDependencies": {
+    "@kitejs-cms/plugin-commerce-api": "workspace:*",
+    "@kitejs-cms/core": "workspace:*",
+    "@kitejs-cms/eslint-config": "workspace:*",
+    "@kitejs-cms/typescript-config": "workspace:*",
+    "@types/react": "19.0.8",
+    "@types/react-dom": "19.0.3",
+    "eslint": "^9.20.0",
+    "tailwindcss-animate": "^1.0.7",
+    "typescript": "5.7.3"
+  }
+}

--- a/packages/plugin-commerce-dashboard/src/components/commerce-settings.tsx
+++ b/packages/plugin-commerce-dashboard/src/components/commerce-settings.tsx
@@ -1,0 +1,243 @@
+import { useEffect, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import type { FieldDefinition } from "@kitejs-cms/core";
+import {
+  Button,
+  Input,
+  Label,
+  Separator,
+  Skeleton,
+  Switch,
+  useSettingsContext,
+} from "@kitejs-cms/dashboard-core";
+import { CustomFieldBuilder } from "@kitejs-cms/dashboard-core/components/custom-field-builder";
+import type { CommercePluginSettingsModel } from "@kitejs-cms/plugin-commerce-api";
+import {
+  COMMERCE_PLUGIN_NAMESPACE,
+  COMMERCE_SETTINGS_KEY,
+} from "../constants";
+
+const DEFAULT_SETTINGS: CommercePluginSettingsModel = {
+  defaultCurrency: "EUR",
+  allowGuestCheckout: true,
+  taxInclusivePricing: false,
+  customProductFields: [],
+  customCustomerAddressFields: [],
+};
+
+export function CommerceSettings() {
+  const { t } = useTranslation("commerce");
+  const {
+    getSetting,
+    updateSetting,
+    hasUnsavedChanges,
+    setHasUnsavedChanges,
+  } = useSettingsContext();
+
+  const [isLoading, setIsLoading] = useState(true);
+  const [defaultCurrency, setDefaultCurrency] = useState(
+    DEFAULT_SETTINGS.defaultCurrency
+  );
+  const [allowGuestCheckout, setAllowGuestCheckout] = useState(
+    DEFAULT_SETTINGS.allowGuestCheckout
+  );
+  const [taxInclusivePricing, setTaxInclusivePricing] = useState(
+    DEFAULT_SETTINGS.taxInclusivePricing
+  );
+  const [productFields, setProductFields] = useState<FieldDefinition[]>(
+    DEFAULT_SETTINGS.customProductFields ?? []
+  );
+  const [addressFields, setAddressFields] = useState<FieldDefinition[]>(
+    DEFAULT_SETTINGS.customCustomerAddressFields ?? []
+  );
+
+  useEffect(() => {
+    const loadSettings = async () => {
+      setIsLoading(true);
+      try {
+        const { value } = await getSetting<{ value: CommercePluginSettingsModel }>(
+          COMMERCE_PLUGIN_NAMESPACE,
+          COMMERCE_SETTINGS_KEY
+        );
+        if (value) {
+          setDefaultCurrency(value.defaultCurrency ?? DEFAULT_SETTINGS.defaultCurrency);
+          setAllowGuestCheckout(
+            value.allowGuestCheckout ?? DEFAULT_SETTINGS.allowGuestCheckout
+          );
+          setTaxInclusivePricing(
+            value.taxInclusivePricing ?? DEFAULT_SETTINGS.taxInclusivePricing
+          );
+          setProductFields(value.customProductFields ?? []);
+          setAddressFields(value.customCustomerAddressFields ?? []);
+        }
+      } catch (error) {
+        console.error("Failed to load commerce settings", error);
+      } finally {
+        setIsLoading(false);
+        setHasUnsavedChanges(false);
+      }
+    };
+
+    void loadSettings();
+  }, [getSetting, setHasUnsavedChanges]);
+
+  const markDirty = () => {
+    setHasUnsavedChanges(true);
+  };
+
+  const handleSave = async () => {
+    setIsLoading(true);
+    try {
+      await updateSetting(COMMERCE_PLUGIN_NAMESPACE, COMMERCE_SETTINGS_KEY, {
+        defaultCurrency,
+        allowGuestCheckout,
+        taxInclusivePricing,
+        customProductFields: productFields,
+        customCustomerAddressFields: addressFields,
+      });
+      setHasUnsavedChanges(false);
+    } catch (error) {
+      console.error("Failed to save commerce settings", error);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const generalDescription = useMemo(
+    () => t("settings.sections.general.description"),
+    [t]
+  );
+
+  if (isLoading && !hasUnsavedChanges) {
+    return (
+      <div className="space-y-6">
+        <Skeleton className="h-36 w-full" />
+        <Skeleton className="h-60 w-full" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-12 pb-16">
+      <section className="space-y-4">
+        <div>
+          <h2 className="text-xl font-semibold">
+            {t("settings.sections.general.title")}
+          </h2>
+          <p className="text-sm text-muted-foreground">{generalDescription}</p>
+        </div>
+        <div className="grid gap-6 md:grid-cols-2">
+          <div className="space-y-2">
+            <Label htmlFor="defaultCurrency">
+              {t("settings.fields.defaultCurrency.label")}
+            </Label>
+            <Input
+              id="defaultCurrency"
+              value={defaultCurrency}
+              onChange={(event) => {
+                setDefaultCurrency(event.target.value.toUpperCase());
+                markDirty();
+              }}
+              maxLength={3}
+            />
+            <p className="text-xs text-muted-foreground">
+              {t("settings.fields.defaultCurrency.description")}
+            </p>
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="allowGuestCheckout">
+              {t("settings.fields.allowGuestCheckout.label")}
+            </Label>
+            <div className="flex items-center justify-between rounded-md border p-4">
+              <div className="space-y-1 pr-4">
+                <p className="text-sm font-medium">
+                  {t("settings.fields.allowGuestCheckout.title")}
+                </p>
+                <p className="text-xs text-muted-foreground">
+                  {t("settings.fields.allowGuestCheckout.description")}
+                </p>
+              </div>
+              <Switch
+                id="allowGuestCheckout"
+                checked={allowGuestCheckout}
+                onCheckedChange={(checked) => {
+                  setAllowGuestCheckout(checked);
+                  markDirty();
+                }}
+              />
+            </div>
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="taxInclusivePricing">
+              {t("settings.fields.taxInclusivePricing.label")}
+            </Label>
+            <div className="flex items-center justify-between rounded-md border p-4">
+              <div className="space-y-1 pr-4">
+                <p className="text-sm font-medium">
+                  {t("settings.fields.taxInclusivePricing.title")}
+                </p>
+                <p className="text-xs text-muted-foreground">
+                  {t("settings.fields.taxInclusivePricing.description")}
+                </p>
+              </div>
+              <Switch
+                id="taxInclusivePricing"
+                checked={taxInclusivePricing}
+                onCheckedChange={(checked) => {
+                  setTaxInclusivePricing(checked);
+                  markDirty();
+                }}
+              />
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <Separator />
+
+      <section className="space-y-4">
+        <div>
+          <h2 className="text-xl font-semibold">
+            {t("settings.sections.productFields.title")}
+          </h2>
+          <p className="text-sm text-muted-foreground">
+            {t("settings.sections.productFields.description")}
+          </p>
+        </div>
+        <CustomFieldBuilder
+          value={productFields}
+          onChange={(fields) => {
+            setProductFields(fields);
+            markDirty();
+          }}
+        />
+      </section>
+
+      <Separator />
+
+      <section className="space-y-4">
+        <div>
+          <h2 className="text-xl font-semibold">
+            {t("settings.sections.addressFields.title")}
+          </h2>
+          <p className="text-sm text-muted-foreground">
+            {t("settings.sections.addressFields.description")}
+          </p>
+        </div>
+        <CustomFieldBuilder
+          value={addressFields}
+          onChange={(fields) => {
+            setAddressFields(fields);
+            markDirty();
+          }}
+        />
+      </section>
+
+      <div className="sticky bottom-6 flex justify-end">
+        <Button onClick={handleSave} disabled={!hasUnsavedChanges}>
+          {t("settings.actions.save")}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/packages/plugin-commerce-dashboard/src/constants/index.ts
+++ b/packages/plugin-commerce-dashboard/src/constants/index.ts
@@ -1,0 +1,4 @@
+export const COMMERCE_PLUGIN_NAMESPACE = "plugin-commerce";
+export const COMMERCE_SETTINGS_KEY = `${COMMERCE_PLUGIN_NAMESPACE}:settings`;
+export const PRODUCT_SETTINGS_KEY = `${COMMERCE_PLUGIN_NAMESPACE}:products`;
+export const ORDER_SETTINGS_KEY = `${COMMERCE_PLUGIN_NAMESPACE}:orders`;

--- a/packages/plugin-commerce-dashboard/src/index.ts
+++ b/packages/plugin-commerce-dashboard/src/index.ts
@@ -1,0 +1,7 @@
+export * from "./module";
+export * from "./constants";
+export * from "./components/commerce-settings";
+export * from "./pages/commerce-products";
+export * from "./pages/commerce-product-details";
+export * from "./pages/commerce-orders";
+export * from "./pages/commerce-order-details";

--- a/packages/plugin-commerce-dashboard/src/index.ts
+++ b/packages/plugin-commerce-dashboard/src/index.ts
@@ -1,7 +1,3 @@
-export * from "./module";
-export * from "./constants";
-export * from "./components/commerce-settings";
-export * from "./pages/commerce-products";
-export * from "./pages/commerce-product-details";
-export * from "./pages/commerce-orders";
-export * from "./pages/commerce-order-details";
+import "./styles.css";
+
+export { CommerceModule } from "./module";

--- a/packages/plugin-commerce-dashboard/src/locales/en.json
+++ b/packages/plugin-commerce-dashboard/src/locales/en.json
@@ -1,0 +1,168 @@
+{
+  "common": {
+    "back": "Back"
+  },
+  "menu": {
+    "commerce": "Commerce",
+    "products": "Products",
+    "orders": "Orders"
+  },
+  "breadcrumb": {
+    "home": "Dashboard",
+    "products": "Products",
+    "orders": "Orders"
+  },
+  "settings": {
+    "description": "Configure the commerce plugin behaviour and customise the data model.",
+    "general": "Commerce settings",
+    "actions": {
+      "save": "Save changes"
+    },
+    "sections": {
+      "general": {
+        "title": "Store preferences",
+        "description": "Default currency and checkout options used across the storefront."
+      },
+      "productFields": {
+        "title": "Product custom fields",
+        "description": "Extend the default product schema with additional attributes."
+      },
+      "addressFields": {
+        "title": "Customer address fields",
+        "description": "Capture extra information for billing and shipping addresses."
+      }
+    },
+    "fields": {
+      "defaultCurrency": {
+        "label": "Default currency",
+        "description": "Used as the pre-filled currency when creating new products."
+      },
+      "allowGuestCheckout": {
+        "label": "Guest checkout",
+        "title": "Allow guest checkout",
+        "description": "Let customers place orders without creating an account."
+      },
+      "taxInclusivePricing": {
+        "label": "Tax inclusive pricing",
+        "title": "Prices include taxes",
+        "description": "Display product prices including taxes by default."
+      }
+    }
+  },
+  "products": {
+    "pageTitle": "Products",
+    "pageDescription": "Manage your catalogue, pricing and availability.",
+    "actions": {
+      "refresh": "Refresh",
+      "create": "New product"
+    },
+    "emptyState": {
+      "title": "No products yet",
+      "description": "Start building your catalogue by creating your first product."
+    },
+    "table": {
+      "columns": {
+        "name": "Name",
+        "status": "Status",
+        "currency": "Currency",
+        "updatedAt": "Last updated"
+      },
+      "untitled": "Untitled product"
+    },
+    "status": {
+      "draft": "Draft",
+      "active": "Active",
+      "archived": "Archived"
+    },
+    "details": {
+      "title": "Product details",
+      "description": "Review the product configuration and localisation.",
+      "breadcrumb": "Product details",
+      "generalInformation": "General information",
+      "status": "Status",
+      "currency": "Default currency",
+      "publishAt": "Scheduled publish",
+      "expireAt": "Scheduled expiration",
+      "contentSection": "Content",
+      "noSummary": "No summary available for this language.",
+      "slug": "Slug",
+      "additionalInformation": "Additional information",
+      "tags": "Tags",
+      "media": "Media",
+      "galleryCount": "{{count}} assets in gallery",
+      "updatedAt": "Last updated"
+    },
+    "create": {
+      "title": "Create product",
+      "description": "The visual editor for products will be available soon.",
+      "helper": "In the meantime you can create products via the API or integrate your own editor interface.",
+      "breadcrumb": "Create product"
+    }
+  },
+  "orders": {
+    "pageTitle": "Orders",
+    "pageDescription": "Track fulfilment, payments and customer information.",
+    "actions": {
+      "refresh": "Refresh"
+    },
+    "emptyState": {
+      "title": "No orders yet",
+      "description": "Orders will appear here as soon as customers start buying."
+    },
+    "table": {
+      "columns": {
+        "number": "Order",
+        "status": "Status",
+        "payment": "Payment",
+        "total": "Total",
+        "updatedAt": "Last updated"
+      }
+    },
+    "status": {
+      "pending": "Pending",
+      "processing": "Processing",
+      "completed": "Completed",
+      "cancelled": "Cancelled"
+    },
+    "paymentStatus": {
+      "awaiting": "Awaiting payment",
+      "authorized": "Authorized",
+      "paid": "Paid",
+      "partially_refunded": "Partially refunded",
+      "refunded": "Refunded"
+    },
+    "fulfillmentStatus": {
+      "unfulfilled": "Unfulfilled",
+      "partially_fulfilled": "Partially fulfilled",
+      "fulfilled": "Fulfilled",
+      "returned": "Returned",
+      "cancelled": "Cancelled"
+    },
+    "details": {
+      "title": "Order {{number}}",
+      "description": "Overview of the order timeline and totals.",
+      "breadcrumb": "Order details",
+      "status": "Order status",
+      "paymentStatus": "Payment status",
+      "fulfillmentStatus": "Fulfilment status",
+      "lastUpdate": "Last update",
+      "subtotal": "Subtotal",
+      "shipping": "Shipping",
+      "tax": "Tax",
+      "discount": "Discount",
+      "total": "Total",
+      "billingAddress": "Billing address",
+      "shippingAddress": "Shipping address",
+      "items": "Order items",
+      "notes": "Internal notes"
+    },
+    "items": {
+      "columns": {
+        "title": "Item",
+        "variant": "Variant",
+        "quantity": "Qty",
+        "total": "Total"
+      }
+    }
+  }
+}

--- a/packages/plugin-commerce-dashboard/src/locales/it.json
+++ b/packages/plugin-commerce-dashboard/src/locales/it.json
@@ -1,0 +1,168 @@
+{
+  "common": {
+    "back": "Indietro"
+  },
+  "menu": {
+    "commerce": "E-commerce",
+    "products": "Prodotti",
+    "orders": "Ordini"
+  },
+  "breadcrumb": {
+    "home": "Bacheca",
+    "products": "Prodotti",
+    "orders": "Ordini"
+  },
+  "settings": {
+    "description": "Configura il comportamento del plugin commerce e personalizza il modello dati.",
+    "general": "Impostazioni commerce",
+    "actions": {
+      "save": "Salva modifiche"
+    },
+    "sections": {
+      "general": {
+        "title": "Preferenze negozio",
+        "description": "Valuta predefinita e opzioni di checkout utilizzate nell'interfaccia."
+      },
+      "productFields": {
+        "title": "Campi personalizzati prodotto",
+        "description": "Estendi lo schema base del prodotto con attributi aggiuntivi."
+      },
+      "addressFields": {
+        "title": "Campi indirizzi cliente",
+        "description": "Raccogli informazioni extra per fatturazione e spedizione."
+      }
+    },
+    "fields": {
+      "defaultCurrency": {
+        "label": "Valuta predefinita",
+        "description": "Utilizzata come valuta proposta durante la creazione di nuovi prodotti."
+      },
+      "allowGuestCheckout": {
+        "label": "Checkout ospite",
+        "title": "Consenti checkout ospite",
+        "description": "Permetti ai clienti di completare l'ordine senza creare un account."
+      },
+      "taxInclusivePricing": {
+        "label": "Prezzi IVA inclusa",
+        "title": "Prezzi comprensivi di tasse",
+        "description": "Mostra i prezzi dei prodotti includendo le imposte per impostazione predefinita."
+      }
+    }
+  },
+  "products": {
+    "pageTitle": "Prodotti",
+    "pageDescription": "Gestisci catalogo, prezzi e disponibilità.",
+    "actions": {
+      "refresh": "Aggiorna",
+      "create": "Nuovo prodotto"
+    },
+    "emptyState": {
+      "title": "Nessun prodotto",
+      "description": "Inizia a costruire il catalogo creando il primo prodotto."
+    },
+    "table": {
+      "columns": {
+        "name": "Nome",
+        "status": "Stato",
+        "currency": "Valuta",
+        "updatedAt": "Ultimo aggiornamento"
+      },
+      "untitled": "Prodotto senza titolo"
+    },
+    "status": {
+      "draft": "Bozza",
+      "active": "Attivo",
+      "archived": "Archiviato"
+    },
+    "details": {
+      "title": "Dettagli prodotto",
+      "description": "Consulta configurazione e localizzazioni del prodotto.",
+      "breadcrumb": "Dettagli prodotto",
+      "generalInformation": "Informazioni generali",
+      "status": "Stato",
+      "currency": "Valuta predefinita",
+      "publishAt": "Pubblicazione programmata",
+      "expireAt": "Scadenza programmata",
+      "contentSection": "Contenuti",
+      "noSummary": "Nessun riassunto disponibile per questa lingua.",
+      "slug": "Slug",
+      "additionalInformation": "Informazioni aggiuntive",
+      "tags": "Tag",
+      "media": "Media",
+      "galleryCount": "{{count}} elementi in galleria",
+      "updatedAt": "Ultimo aggiornamento"
+    },
+    "create": {
+      "title": "Crea prodotto",
+      "description": "L'editor visuale per i prodotti sarà disponibile a breve.",
+      "helper": "Nel frattempo puoi creare prodotti tramite API oppure integrare un editor personalizzato.",
+      "breadcrumb": "Crea prodotto"
+    }
+  },
+  "orders": {
+    "pageTitle": "Ordini",
+    "pageDescription": "Monitora evasioni, pagamenti e informazioni cliente.",
+    "actions": {
+      "refresh": "Aggiorna"
+    },
+    "emptyState": {
+      "title": "Nessun ordine",
+      "description": "Gli ordini appariranno qui non appena i clienti inizieranno ad acquistare."
+    },
+    "table": {
+      "columns": {
+        "number": "Ordine",
+        "status": "Stato",
+        "payment": "Pagamento",
+        "total": "Totale",
+        "updatedAt": "Ultimo aggiornamento"
+      }
+    },
+    "status": {
+      "pending": "In attesa",
+      "processing": "In elaborazione",
+      "completed": "Completato",
+      "cancelled": "Annullato"
+    },
+    "paymentStatus": {
+      "awaiting": "In attesa di pagamento",
+      "authorized": "Autorizzato",
+      "paid": "Pagato",
+      "partially_refunded": "Parzialmente rimborsato",
+      "refunded": "Rimborsato"
+    },
+    "fulfillmentStatus": {
+      "unfulfilled": "Da evadere",
+      "partially_fulfilled": "Parzialmente evaso",
+      "fulfilled": "Evaso",
+      "returned": "Reso",
+      "cancelled": "Annullato"
+    },
+    "details": {
+      "title": "Ordine {{number}}",
+      "description": "Panoramica su tempistiche e totali dell'ordine.",
+      "breadcrumb": "Dettagli ordine",
+      "status": "Stato ordine",
+      "paymentStatus": "Stato pagamento",
+      "fulfillmentStatus": "Stato evasione",
+      "lastUpdate": "Ultimo aggiornamento",
+      "subtotal": "Subtotale",
+      "shipping": "Spedizione",
+      "tax": "Imposte",
+      "discount": "Sconto",
+      "total": "Totale",
+      "billingAddress": "Indirizzo di fatturazione",
+      "shippingAddress": "Indirizzo di spedizione",
+      "items": "Articoli ordine",
+      "notes": "Note interne"
+    },
+    "items": {
+      "columns": {
+        "title": "Articolo",
+        "variant": "Variante",
+        "quantity": "Qt",
+        "total": "Totale"
+      }
+    }
+  }
+}

--- a/packages/plugin-commerce-dashboard/src/module.tsx
+++ b/packages/plugin-commerce-dashboard/src/module.tsx
@@ -1,0 +1,86 @@
+import { Package, ShoppingCart, Truck } from "lucide-react";
+import type { DashboardModule } from "@kitejs-cms/dashboard-core";
+import { CommerceSettings } from "./components/commerce-settings";
+import { CommerceProductsPage } from "./pages/commerce-products";
+import { CommerceProductDetailsPage } from "./pages/commerce-product-details";
+import { CommerceOrdersPage } from "./pages/commerce-orders";
+import { CommerceOrderDetailsPage } from "./pages/commerce-order-details";
+import { COMMERCE_PLUGIN_NAMESPACE } from "./constants";
+
+/* i18n */
+import en from "./locales/en.json";
+import it from "./locales/it.json";
+
+export const CommerceModule: DashboardModule = {
+  key: COMMERCE_PLUGIN_NAMESPACE,
+  name: "commerce",
+  translations: { en, it },
+  settings: {
+    key: COMMERCE_PLUGIN_NAMESPACE,
+    title: "commerce:menu.commerce",
+    icon: <ShoppingCart />,
+    description: "commerce:settings.description",
+    children: [
+      {
+        key: "commerce-settings",
+        title: "commerce:settings.general",
+        icon: <Package />,
+        component: <CommerceSettings />,
+      },
+    ],
+  },
+  routes: [
+    {
+      path: "commerce/products",
+      element: <CommerceProductsPage />,
+      label: "commerce:menu.products",
+      requiredPermissions: ["plugin-commerce:products.read"],
+    },
+    {
+      path: "commerce/products/new",
+      element: <CommerceProductDetailsPage />,
+      label: "",
+      requiredPermissions: ["plugin-commerce:products.create"],
+    },
+    {
+      path: "commerce/products/:id",
+      element: <CommerceProductDetailsPage />,
+      label: "",
+      requiredPermissions: ["plugin-commerce:products.read"],
+    },
+    {
+      path: "commerce/orders",
+      element: <CommerceOrdersPage />,
+      label: "commerce:menu.orders",
+      requiredPermissions: ["plugin-commerce:orders.read"],
+    },
+    {
+      path: "commerce/orders/:id",
+      element: <CommerceOrderDetailsPage />,
+      label: "",
+      requiredPermissions: ["plugin-commerce:orders.read"],
+    },
+  ],
+  menuItem: {
+    title: "commerce:menu.commerce",
+    icon: ShoppingCart,
+    requiredPermissions: [
+      "plugin-commerce:products.read",
+      "plugin-commerce:orders.read",
+    ],
+    items: [
+      {
+        url: "/commerce/products",
+        title: "commerce:menu.products",
+        icon: Package,
+        requiredPermissions: ["plugin-commerce:products.read"],
+      },
+      {
+        url: "/commerce/orders",
+        title: "commerce:menu.orders",
+        icon: Truck,
+        requiredPermissions: ["plugin-commerce:orders.read"],
+      },
+    ],
+  },
+};

--- a/packages/plugin-commerce-dashboard/src/pages/commerce-order-details.tsx
+++ b/packages/plugin-commerce-dashboard/src/pages/commerce-order-details.tsx
@@ -1,0 +1,293 @@
+import type { ReactNode } from "react";
+import { useEffect } from "react";
+import { useTranslation } from "react-i18next";
+import { useNavigate, useParams } from "react-router-dom";
+import {
+  Badge,
+  Button,
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+  Separator,
+  Skeleton,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+  useApi,
+  useBreadcrumb,
+} from "@kitejs-cms/dashboard-core";
+
+interface OrderAddress {
+  firstName?: string;
+  lastName?: string;
+  company?: string;
+  address1?: string;
+  address2?: string;
+  city?: string;
+  postalCode?: string;
+  province?: string;
+  countryCode?: string;
+  phone?: string;
+}
+
+interface OrderItem {
+  id?: string;
+  title: string;
+  variantTitle?: string;
+  quantity: number;
+  unitPrice: number;
+  currencyCode: string;
+  total: number;
+}
+
+interface OrderDetail {
+  id: string;
+  orderNumber: string;
+  status: string;
+  paymentStatus: string;
+  fulfillmentStatus: string;
+  currencyCode: string;
+  subtotal: number;
+  shippingTotal: number;
+  taxTotal: number;
+  discountTotal: number;
+  total: number;
+  tags: string[];
+  notes?: string;
+  email?: string;
+  billingAddress?: OrderAddress;
+  shippingAddress?: OrderAddress;
+  items: OrderItem[];
+  updatedAt?: string;
+  createdAt?: string;
+}
+
+export function CommerceOrderDetailsPage() {
+  const { id } = useParams<{ id: string }>();
+  const { t, i18n } = useTranslation("commerce");
+  const navigate = useNavigate();
+  const { setBreadcrumb } = useBreadcrumb();
+  const { data: order, loading, fetchData } = useApi<OrderDetail>();
+
+  useEffect(() => {
+    setBreadcrumb([
+      { label: t("breadcrumb.home"), path: "/" },
+      { label: t("breadcrumb.orders"), path: "/commerce/orders" },
+      {
+        label: order?.orderNumber ?? t("orders.details.breadcrumb"),
+        path: `/commerce/orders/${id ?? ""}`,
+      },
+    ]);
+  }, [setBreadcrumb, t, order?.orderNumber, id]);
+
+  useEffect(() => {
+    if (id) {
+      void fetchData(`commerce/orders/${id}`);
+    }
+  }, [fetchData, id]);
+
+  if (loading || !order) {
+    return (
+      <div className="space-y-4">
+        <Skeleton className="h-32 w-full" />
+        <Skeleton className="h-24 w-full" />
+      </div>
+    );
+  }
+
+  const formatMoney = (amount: number) => {
+    try {
+      return new Intl.NumberFormat(i18n.language, {
+        style: "currency",
+        currency: order.currencyCode,
+      }).format(amount / 100);
+    } catch {
+      return `${amount / 100} ${order.currencyCode}`;
+    }
+  };
+
+  const formatDateTime = (value?: string) => {
+    if (!value) return "-";
+    try {
+      return new Intl.DateTimeFormat(i18n.language, {
+        year: "numeric",
+        month: "short",
+        day: "numeric",
+        hour: "2-digit",
+        minute: "2-digit",
+      }).format(new Date(value));
+    } catch {
+      return value;
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <Button variant="ghost" onClick={() => navigate(-1)} className="px-0">
+        {t("common.back")}
+      </Button>
+      <Card>
+        <CardHeader>
+          <CardTitle>{t("orders.details.title", { number: order.orderNumber })}</CardTitle>
+          <CardDescription>{t("orders.details.description")}</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          <section className="grid gap-4 md:grid-cols-2">
+            <DetailItem
+              label={t("orders.details.status")}
+              value={
+                <Badge variant="secondary">
+                  {t(`orders.status.${order.status}`, {
+                    defaultValue: order.status,
+                  })}
+                </Badge>
+              }
+            />
+            <DetailItem
+              label={t("orders.details.paymentStatus")}
+              value={
+                <Badge variant="outline">
+                  {t(`orders.paymentStatus.${order.paymentStatus}`, {
+                    defaultValue: order.paymentStatus,
+                  })}
+                </Badge>
+              }
+            />
+            <DetailItem
+              label={t("orders.details.fulfillmentStatus")}
+              value={
+                <Badge variant="outline">
+                  {t(`orders.fulfillmentStatus.${order.fulfillmentStatus}`, {
+                    defaultValue: order.fulfillmentStatus,
+                  })}
+                </Badge>
+              }
+            />
+            <DetailItem
+              label={t("orders.details.lastUpdate")}
+              value={formatDateTime(order.updatedAt)}
+            />
+          </section>
+
+          <Separator />
+
+          <section className="grid gap-4 md:grid-cols-2">
+            <DetailItem
+              label={t("orders.details.subtotal")}
+              value={formatMoney(order.subtotal)}
+            />
+            <DetailItem
+              label={t("orders.details.shipping")}
+              value={formatMoney(order.shippingTotal)}
+            />
+            <DetailItem
+              label={t("orders.details.tax")}
+              value={formatMoney(order.taxTotal)}
+            />
+            <DetailItem
+              label={t("orders.details.discount")}
+              value={formatMoney(order.discountTotal)}
+            />
+            <DetailItem
+              label={t("orders.details.total")}
+              value={formatMoney(order.total)}
+            />
+          </section>
+
+          <Separator />
+
+          <section className="grid gap-6 md:grid-cols-2">
+            <DetailItem
+              label={t("orders.details.billingAddress")}
+              value={formatAddress(order.billingAddress)}
+            />
+            <DetailItem
+              label={t("orders.details.shippingAddress")}
+              value={formatAddress(order.shippingAddress)}
+            />
+          </section>
+
+          <Separator />
+
+          <section className="space-y-3">
+            <h3 className="text-lg font-semibold">{t("orders.details.items")}</h3>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>{t("orders.items.columns.title")}</TableHead>
+                  <TableHead>{t("orders.items.columns.variant")}</TableHead>
+                  <TableHead>{t("orders.items.columns.quantity")}</TableHead>
+                  <TableHead>{t("orders.items.columns.total")}</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {order.items.map((item) => (
+                  <TableRow key={item.id ?? `${item.title}-${item.variantTitle}`}>
+                    <TableCell className="font-medium">{item.title}</TableCell>
+                    <TableCell>{item.variantTitle ?? "-"}</TableCell>
+                    <TableCell>{item.quantity}</TableCell>
+                    <TableCell>{formatMoney(item.total)}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </section>
+
+          {order.notes ? (
+            <section className="space-y-2">
+              <h3 className="text-lg font-semibold">{t("orders.details.notes")}</h3>
+              <p className="rounded-md border bg-muted/50 p-4 text-sm text-muted-foreground">
+                {order.notes}
+              </p>
+            </section>
+          ) : null}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+function formatAddress(address?: OrderAddress): ReactNode {
+  if (!address) {
+    return <span className="text-muted-foreground">-</span>;
+  }
+
+  const lines = [
+    [address.firstName, address.lastName].filter(Boolean).join(" "),
+    address.company,
+    [address.address1, address.address2].filter(Boolean).join(", "),
+    [address.city, address.province, address.postalCode]
+      .filter(Boolean)
+      .join(", "),
+    address.countryCode,
+    address.phone,
+  ]
+    .map((line) => line?.trim())
+    .filter(Boolean);
+
+  if (lines.length === 0) {
+    return <span className="text-muted-foreground">-</span>;
+  }
+
+  return (
+    <div className="space-y-1 text-sm text-foreground">
+      {lines.map((line) => (
+        <div key={line}>{line}</div>
+      ))}
+    </div>
+  );
+}
+
+function DetailItem({ label, value }: { label: string; value: ReactNode }) {
+  return (
+    <div className="space-y-1">
+      <p className="text-sm font-medium text-muted-foreground">{label}</p>
+      <div className="text-sm text-foreground">{value}</div>
+    </div>
+  );
+}

--- a/packages/plugin-commerce-dashboard/src/pages/commerce-orders.tsx
+++ b/packages/plugin-commerce-dashboard/src/pages/commerce-orders.tsx
@@ -1,0 +1,157 @@
+import { useEffect } from "react";
+import { useTranslation } from "react-i18next";
+import { useNavigate } from "react-router-dom";
+import {
+  Badge,
+  Button,
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+  Skeleton,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+  useApi,
+  useBreadcrumb,
+} from "@kitejs-cms/dashboard-core";
+
+interface OrderListItem {
+  id: string;
+  orderNumber: string;
+  status: string;
+  paymentStatus: string;
+  fulfillmentStatus: string;
+  currencyCode: string;
+  total: number;
+  updatedAt?: string;
+}
+
+export function CommerceOrdersPage() {
+  const { t, i18n } = useTranslation("commerce");
+  const navigate = useNavigate();
+  const { setBreadcrumb } = useBreadcrumb();
+  const { data, loading, fetchData } = useApi<OrderListItem[]>();
+
+  useEffect(() => {
+    setBreadcrumb([
+      { label: t("breadcrumb.home"), path: "/" },
+      { label: t("breadcrumb.orders"), path: "/commerce/orders" },
+    ]);
+  }, [setBreadcrumb, t]);
+
+  useEffect(() => {
+    void fetchData("commerce/orders");
+  }, [fetchData]);
+
+  const orders = data ?? [];
+
+  const formatMoney = (amount: number, currency: string) => {
+    try {
+      return new Intl.NumberFormat(i18n.language, {
+        style: "currency",
+        currency,
+      }).format(amount / 100);
+    } catch {
+      return `${amount / 100} ${currency}`;
+    }
+  };
+
+  const formatDate = (value?: string) => {
+    if (!value) return "-";
+    try {
+      return new Intl.DateTimeFormat(i18n.language, {
+        year: "numeric",
+        month: "short",
+        day: "numeric",
+      }).format(new Date(value));
+    } catch {
+      return value;
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+          <div className="space-y-1">
+            <CardTitle>{t("orders.pageTitle")}</CardTitle>
+            <CardDescription>{t("orders.pageDescription")}</CardDescription>
+          </div>
+          <Button
+            variant="outline"
+            onClick={() => fetchData("commerce/orders")}
+            disabled={loading}
+          >
+            {t("orders.actions.refresh")}
+          </Button>
+        </CardHeader>
+        <CardContent>
+          {loading ? (
+            <div className="space-y-4">
+              <Skeleton className="h-12 w-full" />
+              <Skeleton className="h-12 w-full" />
+              <Skeleton className="h-12 w-full" />
+            </div>
+          ) : orders.length === 0 ? (
+            <div className="flex flex-col items-center justify-center gap-2 py-12 text-center">
+              <h3 className="text-lg font-semibold">
+                {t("orders.emptyState.title")}
+              </h3>
+              <p className="max-w-lg text-sm text-muted-foreground">
+                {t("orders.emptyState.description")}
+              </p>
+            </div>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>{t("orders.table.columns.number")}</TableHead>
+                  <TableHead>{t("orders.table.columns.status")}</TableHead>
+                  <TableHead>{t("orders.table.columns.payment")}</TableHead>
+                  <TableHead>{t("orders.table.columns.total")}</TableHead>
+                  <TableHead>{t("orders.table.columns.updatedAt")}</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {orders.map((order) => (
+                  <TableRow
+                    key={order.id}
+                    className="cursor-pointer hover:bg-muted/50"
+                    onClick={() => navigate(`/commerce/orders/${order.id}`)}
+                  >
+                    <TableCell className="font-medium">
+                      {order.orderNumber}
+                    </TableCell>
+                    <TableCell>
+                      <Badge variant="secondary">
+                        {t(`orders.status.${order.status}`, {
+                          defaultValue: order.status,
+                        })}
+                      </Badge>
+                    </TableCell>
+                    <TableCell>
+                      <Badge variant="outline">
+                        {t(`orders.paymentStatus.${order.paymentStatus}`, {
+                          defaultValue: order.paymentStatus,
+                        })}
+                      </Badge>
+                    </TableCell>
+                    <TableCell>
+                      {formatMoney(order.total, order.currencyCode)}
+                    </TableCell>
+                    <TableCell>{formatDate(order.updatedAt)}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/packages/plugin-commerce-dashboard/src/pages/commerce-product-details.tsx
+++ b/packages/plugin-commerce-dashboard/src/pages/commerce-product-details.tsx
@@ -1,0 +1,255 @@
+import type { ReactNode } from "react";
+import { useCallback, useEffect } from "react";
+import { useTranslation } from "react-i18next";
+import { useLocation, useNavigate, useParams } from "react-router-dom";
+import {
+  Badge,
+  Button,
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+  Separator,
+  Skeleton,
+  useApi,
+  useBreadcrumb,
+} from "@kitejs-cms/dashboard-core";
+
+interface ProductTranslation {
+  title?: string;
+  subtitle?: string;
+  summary?: string;
+  description?: string;
+  slug?: string;
+}
+
+interface ProductDetail {
+  id: string;
+  status?: string;
+  tags?: string[];
+  defaultCurrency?: string;
+  publishAt?: string | null;
+  expireAt?: string | null;
+  gallery?: string[];
+  slugs: Record<string, string>;
+  translations: Record<string, ProductTranslation>;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+export function CommerceProductDetailsPage() {
+  const { id } = useParams<{ id: string }>();
+  const location = useLocation();
+  const { t, i18n } = useTranslation("commerce");
+  const navigate = useNavigate();
+  const { setBreadcrumb } = useBreadcrumb();
+  const isCreating = !id && location.pathname.endsWith("/new");
+  const {
+    data: product,
+    loading,
+    fetchData,
+  } = useApi<ProductDetail>();
+
+  const resolveProductTitle = useCallback(
+    (current?: ProductDetail) => {
+      if (!current) {
+        return t("products.details.breadcrumb");
+      }
+      const translation =
+        current.translations?.[i18n.language] ?? current.translations?.en;
+      if (translation?.title) {
+        return translation.title;
+      }
+      return t("products.details.breadcrumb");
+    },
+    [i18n.language, t]
+  );
+
+  useEffect(() => {
+    setBreadcrumb([
+      { label: t("breadcrumb.home"), path: "/" },
+      { label: t("breadcrumb.products"), path: "/commerce/products" },
+      isCreating
+        ? { label: t("products.create.breadcrumb"), path: location.pathname }
+        : {
+            label: resolveProductTitle(product ?? undefined),
+            path: location.pathname,
+          },
+    ]);
+  }, [
+    setBreadcrumb,
+    t,
+    location.pathname,
+    isCreating,
+    product,
+    resolveProductTitle,
+  ]);
+
+  useEffect(() => {
+    if (!isCreating && id) {
+      void fetchData(`commerce/products/${id}`);
+    }
+  }, [fetchData, id, isCreating]);
+
+  if (isCreating) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>{t("products.create.title")}</CardTitle>
+          <CardDescription>{t("products.create.description")}</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <p className="text-sm text-muted-foreground">
+            {t("products.create.helper")}
+          </p>
+          <Button onClick={() => navigate(-1)} variant="outline">
+            {t("common.back")}
+          </Button>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (loading || !product) {
+    return (
+      <div className="space-y-4">
+        <Skeleton className="h-32 w-full" />
+        <Skeleton className="h-24 w-full" />
+      </div>
+    );
+  }
+
+  const translation =
+    product.translations?.[i18n.language] ?? product.translations?.en ?? {};
+
+  const formatDateTime = (value?: string | null) => {
+    if (!value) return "-";
+    try {
+      return new Intl.DateTimeFormat(i18n.language, {
+        year: "numeric",
+        month: "short",
+        day: "numeric",
+        hour: "2-digit",
+        minute: "2-digit",
+      }).format(new Date(value));
+    } catch {
+      return value;
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <Button variant="ghost" onClick={() => navigate(-1)} className="px-0">
+        {t("common.back")}
+      </Button>
+      <Card>
+        <CardHeader>
+          <CardTitle>{translation.title ?? t("products.details.title")}</CardTitle>
+          <CardDescription>
+            {translation.subtitle ?? t("products.details.description")}
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          <section className="space-y-3">
+            <h3 className="text-lg font-semibold">
+              {t("products.details.generalInformation")}
+            </h3>
+            <div className="grid gap-4 md:grid-cols-2">
+              <DetailItem
+                label={t("products.details.status")}
+                value={
+                  product.status ? (
+                    <Badge variant="secondary">
+                      {t(`products.status.${product.status}`, {
+                        defaultValue: product.status,
+                      })}
+                    </Badge>
+                  ) : (
+                    "-"
+                  )
+                }
+              />
+              <DetailItem
+                label={t("products.details.currency")}
+                value={product.defaultCurrency ?? "-"}
+              />
+              <DetailItem
+                label={t("products.details.publishAt")}
+                value={formatDateTime(product.publishAt)}
+              />
+              <DetailItem
+                label={t("products.details.expireAt")}
+                value={formatDateTime(product.expireAt)}
+              />
+            </div>
+          </section>
+
+          <Separator />
+
+          <section className="space-y-3">
+            <h3 className="text-lg font-semibold">
+              {t("products.details.contentSection")}
+            </h3>
+            <p className="text-sm text-muted-foreground">
+              {translation.summary ?? t("products.details.noSummary")}
+            </p>
+            <DetailItem
+              label={t("products.details.slug")}
+              value={translation.slug ?? product.slugs?.[i18n.language] ?? "-"}
+            />
+          </section>
+
+          <Separator />
+
+          <section className="space-y-3">
+            <h3 className="text-lg font-semibold">
+              {t("products.details.additionalInformation")}
+            </h3>
+            <DetailItem
+              label={t("products.details.tags")}
+              value={
+                product.tags?.length ? (
+                  <div className="flex flex-wrap gap-2">
+                    {product.tags.map((tag) => (
+                      <Badge key={tag} variant="outline">
+                        {tag}
+                      </Badge>
+                    ))}
+                  </div>
+                ) : (
+                  <span className="text-muted-foreground">-</span>
+                )
+              }
+            />
+            <DetailItem
+              label={t("products.details.media")}
+              value={t("products.details.galleryCount", {
+                count: product.gallery?.length ?? 0,
+              })}
+            />
+            <DetailItem
+              label={t("products.details.updatedAt")}
+              value={formatDateTime(product.updatedAt)}
+            />
+          </section>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+function DetailItem({
+  label,
+  value,
+}: {
+  label: string;
+  value: ReactNode;
+}) {
+  return (
+    <div className="space-y-1">
+      <p className="text-sm font-medium text-muted-foreground">{label}</p>
+      <div className="text-sm text-foreground">{value}</div>
+    </div>
+  );
+}

--- a/packages/plugin-commerce-dashboard/src/pages/commerce-products.tsx
+++ b/packages/plugin-commerce-dashboard/src/pages/commerce-products.tsx
@@ -1,0 +1,163 @@
+import { useEffect } from "react";
+import { useTranslation } from "react-i18next";
+import { useNavigate } from "react-router-dom";
+import {
+  Badge,
+  Button,
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+  Skeleton,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+  useApi,
+  useBreadcrumb,
+  useHasPermission,
+} from "@kitejs-cms/dashboard-core";
+
+interface ProductListItem {
+  id: string;
+  status?: string;
+  tags?: string[];
+  defaultCurrency?: string;
+  publishAt?: string | null;
+  translations: Record<string, Record<string, unknown>>;
+  updatedAt?: string;
+}
+
+export function CommerceProductsPage() {
+  const { t, i18n } = useTranslation("commerce");
+  const navigate = useNavigate();
+  const { setBreadcrumb } = useBreadcrumb();
+  const { data, loading, fetchData } = useApi<ProductListItem[]>();
+  const hasPermission = useHasPermission();
+  const canCreate = hasPermission("plugin-commerce:products.create");
+
+  useEffect(() => {
+    setBreadcrumb([
+      { label: t("breadcrumb.home"), path: "/" },
+      { label: t("breadcrumb.products"), path: "/commerce/products" },
+    ]);
+  }, [setBreadcrumb, t]);
+
+  useEffect(() => {
+    void fetchData("commerce/products");
+  }, [fetchData]);
+
+  const products = data ?? [];
+
+  const getProductTitle = (product: ProductListItem) => {
+    const language = i18n.language || "en";
+    const translation = product.translations?.[language] ?? product.translations?.en;
+    if (translation && typeof translation.title === "string") {
+      return translation.title as string;
+    }
+    return t("products.table.untitled");
+  };
+
+  const formatDate = (value?: string | null) => {
+    if (!value) return "-";
+    try {
+      return new Intl.DateTimeFormat(i18n.language, {
+        year: "numeric",
+        month: "short",
+        day: "numeric",
+      }).format(new Date(value));
+    } catch {
+      return value;
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+          <div className="space-y-1">
+            <CardTitle>{t("products.pageTitle")}</CardTitle>
+            <CardDescription>{t("products.pageDescription")}</CardDescription>
+          </div>
+          <div className="flex gap-2">
+            <Button
+              variant="outline"
+              onClick={() => fetchData("commerce/products")}
+              disabled={loading}
+            >
+              {t("products.actions.refresh")}
+            </Button>
+            {canCreate ? (
+              <Button onClick={() => navigate("/commerce/products/new")}>
+                {t("products.actions.create")}
+              </Button>
+            ) : null}
+          </div>
+        </CardHeader>
+        <CardContent>
+          {loading ? (
+            <div className="space-y-4">
+              <Skeleton className="h-12 w-full" />
+              <Skeleton className="h-12 w-full" />
+              <Skeleton className="h-12 w-full" />
+            </div>
+          ) : products.length === 0 ? (
+            <div className="flex flex-col items-center justify-center gap-2 py-12 text-center">
+              <h3 className="text-lg font-semibold">
+                {t("products.emptyState.title")}
+              </h3>
+              <p className="max-w-lg text-sm text-muted-foreground">
+                {t("products.emptyState.description")}
+              </p>
+              {canCreate ? (
+                <Button onClick={() => navigate("/commerce/products/new")}>
+                  {t("products.actions.create")}
+                </Button>
+              ) : null}
+            </div>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>{t("products.table.columns.name")}</TableHead>
+                  <TableHead>{t("products.table.columns.status")}</TableHead>
+                  <TableHead>{t("products.table.columns.currency")}</TableHead>
+                  <TableHead>{t("products.table.columns.updatedAt")}</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {products.map((product) => (
+                  <TableRow
+                    key={product.id}
+                    className="cursor-pointer hover:bg-muted/50"
+                    onClick={() => navigate(`/commerce/products/${product.id}`)}
+                  >
+                    <TableCell className="font-medium">
+                      {getProductTitle(product)}
+                    </TableCell>
+                    <TableCell>
+                      {product.status ? (
+                        <Badge variant="secondary">
+                          {t(`products.status.${product.status}`, {
+                            defaultValue: product.status,
+                          })}
+                        </Badge>
+                      ) : (
+                        <span className="text-muted-foreground">-</span>
+                      )}
+                    </TableCell>
+                    <TableCell>{product.defaultCurrency ?? "-"}</TableCell>
+                    <TableCell>{formatDate(product.updatedAt)}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/packages/plugin-commerce-dashboard/src/styles.css
+++ b/packages/plugin-commerce-dashboard/src/styles.css
@@ -1,0 +1,1 @@
+@import "tailwindcss";

--- a/packages/plugin-commerce-dashboard/tailwind.config.ts
+++ b/packages/plugin-commerce-dashboard/tailwind.config.ts
@@ -1,0 +1,53 @@
+import type { Config } from "tailwindcss";
+import TailwindcssAnimate from "tailwindcss-animate";
+
+const config: Config = {
+  content: ["./src/**/*.tsx"],
+  plugins: [TailwindcssAnimate],
+  theme: {
+    extend: {
+      colors: {
+        border: "hsl(var(--border))",
+        input: "hsl(var(--input))",
+        ring: "hsl(var(--ring))",
+        background: "hsl(var(--background))",
+        foreground: "hsl(var(--foreground))",
+        primary: {
+          DEFAULT: "hsl(var(--primary))",
+          foreground: "hsl(var(--primary-foreground))",
+        },
+        secondary: {
+          DEFAULT: "hsl(var(--secondary))",
+          foreground: "hsl(var(--secondary-foreground))",
+        },
+        destructive: {
+          DEFAULT: "hsl(var(--destructive))",
+          foreground: "hsl(var(--destructive-foreground))",
+        },
+        muted: {
+          DEFAULT: "hsl(var(--muted))",
+          foreground: "hsl(var(--muted-foreground))",
+        },
+        accent: {
+          DEFAULT: "hsl(var(--accent))",
+          foreground: "hsl(var(--accent-foreground))",
+        },
+        popover: {
+          DEFAULT: "hsl(var(--popover))",
+          foreground: "hsl(var(--popover-foreground))",
+        },
+        card: {
+          DEFAULT: "hsl(var(--card))",
+          foreground: "hsl(var(--card-foreground))",
+        },
+      },
+      borderRadius: {
+        lg: `var(--radius)`,
+        md: `calc(var(--radius) - 2px)`,
+        sm: "calc(var(--radius) - 4px)",
+      },
+    },
+  },
+};
+
+export default config;

--- a/packages/plugin-commerce-dashboard/tsconfig.json
+++ b/packages/plugin-commerce-dashboard/tsconfig.json
@@ -11,18 +11,7 @@
     "skipLibCheck": true,
     "module": "ES2022",
     "esModuleInterop": true,
-    "moduleResolution": "bundler",
-    "paths": {
-      "@kitejs-cms/dashboard-core": ["../dashboard-core/src"],
-      "@kitejs-cms/dashboard-core/*": ["../dashboard-core/src/*"],
-      "@kitejs-cms/plugin-commerce-api": ["../plugin-commerce-api/src"],
-      "@kitejs-cms/plugin-commerce-api/*": ["../plugin-commerce-api/src/*"],
-      "@kitejs-cms/core": ["../core/src"],
-      "@kitejs-cms/core/*": ["../core/src/*"],
-      "@kitejs-cms/dashboard-core/components/*": [
-        "../dashboard-core/src/components/*"
-      ]
-    }
+    "moduleResolution": "bundler"
   },
   "include": ["src"],
   "exclude": ["node_modules", "dist"]

--- a/packages/plugin-commerce-dashboard/tsconfig.json
+++ b/packages/plugin-commerce-dashboard/tsconfig.json
@@ -1,0 +1,29 @@
+{
+  "extends": "@kitejs-cms/typescript-config/react-library.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "noImplicitAny": false,
+    "strictNullChecks": false,
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": false,
+    "strictPropertyInitialization": false,
+    "isolatedModules": false,
+    "skipLibCheck": true,
+    "module": "ES2022",
+    "esModuleInterop": true,
+    "moduleResolution": "bundler",
+    "paths": {
+      "@kitejs-cms/dashboard-core": ["../dashboard-core/src"],
+      "@kitejs-cms/dashboard-core/*": ["../dashboard-core/src/*"],
+      "@kitejs-cms/plugin-commerce-api": ["../plugin-commerce-api/src"],
+      "@kitejs-cms/plugin-commerce-api/*": ["../plugin-commerce-api/src/*"],
+      "@kitejs-cms/core": ["../core/src"],
+      "@kitejs-cms/core/*": ["../core/src/*"],
+      "@kitejs-cms/dashboard-core/components/*": [
+        "../dashboard-core/src/components/*"
+      ]
+    }
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/plugin-gallery-dashboard/package.json
+++ b/packages/plugin-gallery-dashboard/package.json
@@ -36,8 +36,8 @@
   },
   "peerDependencies": {
     "@kitejs-cms/dashboard-core": "workspace:*",
-    "react": "^18.2.0 || ^19.0.0",
-    "react-dom": "^18.2.0 || ^19.0.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
     "react-i18next": "^15.4.1",
     "react-router-dom": "^7.2.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -142,6 +142,9 @@ importers:
       '@kitejs-cms/plugin-analytics-dashboard':
         specifier: workspace:*
         version: link:../../packages/plugin-analytics-dashboard
+      '@kitejs-cms/plugin-commerce-dashboard':
+        specifier: workspace:*
+        version: link:../../packages/plugin-commerce-dashboard
       '@kitejs-cms/plugin-gallery-dashboard':
         specifier: workspace:*
         version: link:../../packages/plugin-gallery-dashboard
@@ -672,13 +675,13 @@ importers:
         specifier: ^0.475.0
         version: 0.475.0(react@19.1.1)
       react:
-        specifier: ^18.2.0 || ^19.0.0
+        specifier: ^19.0.0
         version: 19.1.1
       react-day-picker:
         specifier: ^9.9.0
         version: 9.9.0(react@19.1.1)
       react-dom:
-        specifier: ^18.2.0 || ^19.0.0
+        specifier: ^19.0.0
         version: 19.1.1(react@19.1.1)
       react-i18next:
         specifier: ^15.4.1
@@ -809,6 +812,55 @@ importers:
         specifier: ^5.7.3
         version: 5.7.3
 
+  packages/plugin-commerce-dashboard:
+    dependencies:
+      '@kitejs-cms/dashboard-core':
+        specifier: workspace:*
+        version: link:../dashboard-core
+      lucide-react:
+        specifier: ^0.475.0
+        version: 0.475.0(react@19.1.1)
+      react:
+        specifier: ^19.0.0
+        version: 19.1.1
+      react-dom:
+        specifier: ^19.0.0
+        version: 19.1.1(react@19.1.1)
+      react-i18next:
+        specifier: ^15.4.1
+        version: 15.7.3(i18next@24.2.3(typescript@5.7.3))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.7.3)
+      react-router-dom:
+        specifier: ^7.2.0
+        version: 7.8.2(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+    devDependencies:
+      '@kitejs-cms/core':
+        specifier: workspace:*
+        version: link:../core
+      '@kitejs-cms/eslint-config':
+        specifier: workspace:*
+        version: link:../eslint-config
+      '@kitejs-cms/plugin-commerce-api':
+        specifier: workspace:*
+        version: link:../plugin-commerce-api
+      '@kitejs-cms/typescript-config':
+        specifier: workspace:*
+        version: link:../typescript-config
+      '@types/react':
+        specifier: 19.0.8
+        version: 19.0.8
+      '@types/react-dom':
+        specifier: 19.0.3
+        version: 19.0.3(@types/react@19.0.8)
+      eslint:
+        specifier: ^9.20.0
+        version: 9.35.0(jiti@2.5.1)
+      tailwindcss-animate:
+        specifier: ^1.0.7
+        version: 1.0.7(tailwindcss@4.1.13)
+      typescript:
+        specifier: 5.7.3
+        version: 5.7.3
+
   packages/plugin-gallery-api:
     dependencies:
       '@kitejs-cms/core':
@@ -879,10 +931,10 @@ importers:
         specifier: ^0.475.0
         version: 0.475.0(react@19.1.1)
       react:
-        specifier: ^18.2.0 || ^19.0.0
+        specifier: ^19.0.0
         version: 19.1.1
       react-dom:
-        specifier: ^18.2.0 || ^19.0.0
+        specifier: ^19.0.0
         version: 19.1.1(react@19.1.1)
       react-i18next:
         specifier: ^15.4.1

--- a/turbo.json
+++ b/turbo.json
@@ -1,15 +1,11 @@
 {
   "$schema": "https://turbo.build/schema.json",
   "ui": "tui",
+  "concurrency": "20",
   "tasks": {
     "build": {
-      "dependsOn": [
-        "^build"
-      ],
-      "inputs": [
-        "$TURBO_DEFAULT$",
-        ".env*"
-      ],
+      "dependsOn": ["^build"],
+      "inputs": ["$TURBO_DEFAULT$", ".env*"],
       "outputs": [
         "dist/**",
         ".next/**",
@@ -19,21 +15,15 @@
       ]
     },
     "dev": {
-      "dependsOn": [
-        "^build"
-      ],
+      "dependsOn": ["^build"],
       "cache": false,
       "persistent": true
     },
     "lint": {
-      "dependsOn": [
-        "^build"
-      ]
+      "dependsOn": ["^build"]
     },
     "check-types": {
-      "dependsOn": [
-        "^build"
-      ]
+      "dependsOn": ["^build"]
     }
   }
 }


### PR DESCRIPTION
## Summary
- add the new `@kitejs-cms/plugin-commerce-dashboard` package with module registration, translations, and styles
- implement product and order management pages along with detailed views tailored to the commerce API
- provide configurable commerce settings for currency, checkout preferences, and custom fields