### PR TITLE
feat: add commerce collection management UI

### DIFF
--- a/packages/dashboard-core/src/components/data-table.tsx
+++ b/packages/dashboard-core/src/components/data-table.tsx
@@ -39,6 +39,7 @@ interface TableProps<T> {
   isLoading?: boolean;
   pagination?: PaginationProps;
   onRowClick?: (row: T) => void;
+  emptyMessage?: React.ReactNode;
 }
 
 const alignClass = {
@@ -53,7 +54,12 @@ export function DataTable<T>({
   isLoading,
   pagination,
   onRowClick,
+  emptyMessage,
 }: TableProps<T>) {
+  const { t } = useTranslation("components");
+
+  const noDataContent = emptyMessage ?? t("data-table.empty", { defaultValue: "No entries found" });
+
   return (
     <Table>
       <TableHeader>
@@ -71,16 +77,16 @@ export function DataTable<T>({
       <TableBody>
         {isLoading ? (
           <TableRow>
-            <TableCell colSpan={columns.length} className="text-center py-6">
-              <Loader2 className="animate-spin h-6 w-6 text-primary mx-auto scale-110" />
+            <TableCell colSpan={columns.length} className="py-6 text-center">
+              <Loader2 className="mx-auto h-6 w-6 animate-spin text-primary" />
             </TableCell>
           </TableRow>
-        ) : (
-          (data || []).map((row, rowIndex) => (
+        ) : data && data.length > 0 ? (
+          data.map((row, rowIndex) => (
             <TableRow
               key={rowIndex}
               onClick={() => onRowClick?.(row)}
-              className="cursor-pointer hover:bg-gray-100"
+              className={onRowClick ? "cursor-pointer hover:bg-muted/50" : undefined}
             >
               {columns.map((col) => (
                 <TableCell
@@ -94,6 +100,15 @@ export function DataTable<T>({
               ))}
             </TableRow>
           ))
+        ) : (
+          <TableRow className="hover:bg-transparent">
+            <TableCell
+              colSpan={columns.length}
+              className="py-6 text-center text-sm text-muted-foreground"
+            >
+              {noDataContent}
+            </TableCell>
+          </TableRow>
         )}
       </TableBody>
       {pagination && (

--- a/packages/dashboard-core/src/index.ts
+++ b/packages/dashboard-core/src/index.ts
@@ -30,6 +30,7 @@ export * from "./components/file-uploader";
 export * from "./components/filter-modal";
 export * from "./components/data-table";
 export * from "./components/json-modal";
+export * from "./modules/pages/components/languages-badge";
 
 /* Provider */
 export * from "./dashboard-provider";

--- a/packages/dashboard-core/src/locales/en/components.json
+++ b/packages/dashboard-core/src/locales/en/components.json
@@ -12,6 +12,9 @@
     "morePages": "More pages",
     "pageInfo": "Page {{current}} of {{total}}"
   },
+  "data-table": {
+    "empty": "No entries found"
+  },
   "nav-user": {
     "account": "Account",
     "settings": "Settings",

--- a/packages/dashboard-core/src/locales/it/components.json
+++ b/packages/dashboard-core/src/locales/it/components.json
@@ -12,6 +12,9 @@
     "morePages": "Altre pagine",
     "pageInfo": "Pagina {{current}} di {{total}}"
   },
+  "data-table": {
+    "empty": "Nessun elemento presente"
+  },
   "nav-user": {
     "account": "Account",
     "settings": "Impostazioni",

--- a/packages/plugin-commerce-dashboard/src/components/collection-language-tabs.tsx
+++ b/packages/plugin-commerce-dashboard/src/components/collection-language-tabs.tsx
@@ -1,0 +1,96 @@
+import { useEffect, useMemo } from "react";
+import {
+  Tabs,
+  TabsList,
+  TabsTrigger,
+  Button,
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+} from "@kitejs-cms/dashboard-core";
+import { useSettingsContext } from "@kitejs-cms/dashboard-core";
+import { Plus } from "lucide-react";
+
+interface CollectionLanguageTabsProps {
+  languages: string[];
+  activeLanguage: string;
+  onLanguageChange: (language: string) => void;
+  onAddLanguage: (language: string) => void;
+}
+
+export function CollectionLanguageTabs({
+  languages,
+  activeLanguage,
+  onLanguageChange,
+  onAddLanguage,
+}: CollectionLanguageTabsProps) {
+  const { cmsSettings } = useSettingsContext();
+
+  const supportedLanguages = useMemo(
+    () => cmsSettings?.supportedLanguages ?? [],
+    [cmsSettings?.supportedLanguages]
+  );
+
+  const sortedLanguages = useMemo(() => {
+    return [...languages].sort((a, b) => {
+      if (a === cmsSettings?.defaultLanguage) return -1;
+      if (b === cmsSettings?.defaultLanguage) return 1;
+      return a.localeCompare(b);
+    });
+  }, [languages, cmsSettings?.defaultLanguage]);
+
+  const missingLanguages = useMemo(
+    () => supportedLanguages.filter((language) => !languages.includes(language)),
+    [languages, supportedLanguages]
+  );
+
+  useEffect(() => {
+    if (!languages.includes(activeLanguage)) {
+      const fallback =
+        sortedLanguages[0] ?? supportedLanguages[0] ?? cmsSettings?.defaultLanguage ?? "en";
+      if (fallback) {
+        onLanguageChange(fallback);
+      }
+    }
+  }, [
+    activeLanguage,
+    languages,
+    sortedLanguages,
+    supportedLanguages,
+    cmsSettings?.defaultLanguage,
+    onLanguageChange,
+  ]);
+
+  return (
+    <Tabs value={activeLanguage} onValueChange={onLanguageChange}>
+      <TabsList className="flex-wrap h-auto gap-2">
+        {sortedLanguages.map((language) => (
+          <TabsTrigger key={language} value={language} className="text-sm">
+            {language.toUpperCase()}
+            {language === cmsSettings?.defaultLanguage && (
+              <span className="ml-1 text-xs text-muted-foreground">(default)</span>
+            )}
+          </TabsTrigger>
+        ))}
+
+        {missingLanguages.length > 0 && (
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant="ghost" size="sm" className="h-8">
+                <Plus className="h-3.5 w-3.5" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              {missingLanguages.map((language) => (
+                <DropdownMenuItem key={language} onClick={() => onAddLanguage(language)}>
+                  {language.toUpperCase()}
+                </DropdownMenuItem>
+              ))}
+            </DropdownMenuContent>
+          </DropdownMenu>
+        )}
+      </TabsList>
+    </Tabs>
+  );
+}

--- a/packages/plugin-commerce-dashboard/src/locales/en.json
+++ b/packages/plugin-commerce-dashboard/src/locales/en.json
@@ -58,7 +58,8 @@
       "manage": "Manage collections"
     },
     "search": {
-      "placeholder": "Search collections..."
+      "placeholder": "Search collections...",
+      "minLength": "Enter at least 3 characters to search."
     },
     "fields": {
       "title": "Title",
@@ -67,6 +68,7 @@
       "status": "Status",
       "publishAt": "Publish at",
       "updatedAt": "Last updated",
+      "createdAt": "Created at",
       "actions": "Actions",
       "slug": "Slug",
       "description": "Description",
@@ -98,6 +100,17 @@
       "untitled": "Untitled collection",
       "error": "Unable to load collections. Please retry.",
       "empty": "No collections match the current filters."
+    },
+    "filters": {
+      "active": "{{count}} active filters",
+      "clear": "Clear filters",
+      "fields": {
+        "status": "Status",
+        "tags": "Tags",
+        "publishAt": "Publish at",
+        "expireAt": "Unpublish at",
+        "createdAt": "Created at"
+      }
     },
     "status": {
       "Draft": "Draft",

--- a/packages/plugin-commerce-dashboard/src/locales/en.json
+++ b/packages/plugin-commerce-dashboard/src/locales/en.json
@@ -75,6 +75,7 @@
     "sections": {
       "details": "Details",
       "settings": "Settings",
+      "seo": "SEO",
       "meta": "Metadata"
     },
     "buttons": {
@@ -106,6 +107,12 @@
     "meta": {
       "created": "Created",
       "updated": "Last updated"
+    },
+    "seo": {
+      "metaTitle": "Meta title",
+      "metaDescription": "Meta description",
+      "metaKeywords": "Meta keywords",
+      "canonicalUrl": "Canonical URL"
     },
     "details": {
       "title": "Collection details",

--- a/packages/plugin-commerce-dashboard/src/locales/en.json
+++ b/packages/plugin-commerce-dashboard/src/locales/en.json
@@ -54,16 +54,38 @@
   "collections": {
     "pageTitle": "Collections",
     "pageDescription": "Group products into curated selections to power landing pages and campaigns.",
-    "actions": {
-      "refresh": "Refresh",
-      "create": "New collection",
-      "search": "Search collections",
-      "open": "Open details",
-      "delete": "Delete"
+    "title": {
+      "manage": "Manage collections"
     },
-    "emptyState": {
-      "title": "No collections yet",
-      "description": "Create your first collection to organise products for campaigns and navigation."
+    "search": {
+      "placeholder": "Search collections..."
+    },
+    "fields": {
+      "title": "Title",
+      "languages": "Languages",
+      "tags": "Tags",
+      "status": "Status",
+      "publishAt": "Publish at",
+      "updatedAt": "Last updated",
+      "actions": "Actions",
+      "slug": "Slug",
+      "description": "Description",
+      "expireAt": "Unpublish at"
+    },
+    "sections": {
+      "details": "Details",
+      "settings": "Settings",
+      "meta": "Metadata"
+    },
+    "buttons": {
+      "add": "Add collection",
+      "copy": "Copy",
+      "download": "Download",
+      "edit": "Edit",
+      "delete": "Delete",
+      "viewJson": "View JSON",
+      "cancel": "Cancel",
+      "save": "Save"
     },
     "table": {
       "columns": {
@@ -80,6 +102,10 @@
       "Draft": "Draft",
       "Published": "Published",
       "Archived": "Archived"
+    },
+    "meta": {
+      "created": "Created",
+      "updated": "Last updated"
     },
     "details": {
       "title": "Collection details",

--- a/packages/plugin-commerce-dashboard/src/locales/en.json
+++ b/packages/plugin-commerce-dashboard/src/locales/en.json
@@ -73,7 +73,8 @@
         "updatedAt": "Last updated"
       },
       "untitled": "Untitled collection",
-      "error": "Unable to load collections. Please retry."
+      "error": "Unable to load collections. Please retry.",
+      "empty": "No collections match the current filters."
     },
     "status": {
       "Draft": "Draft",

--- a/packages/plugin-commerce-dashboard/src/locales/en.json
+++ b/packages/plugin-commerce-dashboard/src/locales/en.json
@@ -4,11 +4,13 @@
   },
   "menu": {
     "commerce": "Commerce",
+    "collections": "Collections",
     "products": "Products",
     "orders": "Orders"
   },
   "breadcrumb": {
     "home": "Dashboard",
+    "collections": "Collections",
     "products": "Products",
     "orders": "Orders"
   },
@@ -47,6 +49,81 @@
         "title": "Prices include taxes",
         "description": "Display product prices including taxes by default."
       }
+    }
+  },
+  "collections": {
+    "pageTitle": "Collections",
+    "pageDescription": "Group products into curated selections to power landing pages and campaigns.",
+    "actions": {
+      "refresh": "Refresh",
+      "create": "New collection",
+      "search": "Search collections",
+      "open": "Open details",
+      "delete": "Delete"
+    },
+    "emptyState": {
+      "title": "No collections yet",
+      "description": "Create your first collection to organise products for campaigns and navigation."
+    },
+    "table": {
+      "columns": {
+        "name": "Name",
+        "status": "Status",
+        "tags": "Tags",
+        "updatedAt": "Last updated"
+      },
+      "untitled": "Untitled collection",
+      "error": "Unable to load collections. Please retry."
+    },
+    "status": {
+      "Draft": "Draft",
+      "Published": "Published",
+      "Archived": "Archived"
+    },
+    "details": {
+      "title": "Collection details",
+      "description": "Define the content and publication rules for this collection.",
+      "breadcrumb": "Collection details",
+      "language": "Language",
+      "name": "Title",
+      "namePlaceholder": "Collection name",
+      "slug": "Slug",
+      "slugPlaceholder": "collection-slug",
+      "descriptionPlaceholder": "Describe the purpose of this collection.",
+      "status": "Status",
+      "tags": "Tags",
+      "tagPlaceholder": "Add a tag and press enter",
+      "addTag": "Add tag",
+      "removeTag": "Remove tag \"{{tag}}\"",
+      "noTags": "No tags added yet.",
+      "publishAt": "Publish at",
+      "expireAt": "Unpublish at",
+      "meta": {
+        "title": "Metadata",
+        "created": "Created",
+        "updated": "Last updated"
+      },
+      "actions": {
+        "save": "Save collection",
+        "cancel": "Cancel"
+      },
+      "notifications": {
+        "saved": "Collection updated successfully.",
+        "created": "Collection created successfully.",
+        "validationError": "Please provide a title and slug for the selected language.",
+        "error": "Unable to save the collection. Please try again."
+      }
+    },
+    "create": {
+      "title": "Create collection",
+      "description": "Set up the first translation and availability for the new collection.",
+      "breadcrumb": "Create collection"
+    },
+    "delete": {
+      "title": "Delete collection",
+      "description": "This action cannot be undone. Are you sure you want to delete the collection?",
+      "confirm": "Delete",
+      "cancel": "Cancel"
     }
   },
   "products": {

--- a/packages/plugin-commerce-dashboard/src/locales/it.json
+++ b/packages/plugin-commerce-dashboard/src/locales/it.json
@@ -73,7 +73,8 @@
         "updatedAt": "Ultimo aggiornamento"
       },
       "untitled": "Collezione senza titolo",
-      "error": "Impossibile caricare le collezioni. Riprova."
+      "error": "Impossibile caricare le collezioni. Riprova.",
+      "empty": "Nessuna collezione corrisponde ai filtri attuali."
     },
     "status": {
       "Draft": "Bozza",

--- a/packages/plugin-commerce-dashboard/src/locales/it.json
+++ b/packages/plugin-commerce-dashboard/src/locales/it.json
@@ -75,6 +75,7 @@
     "sections": {
       "details": "Dettagli",
       "settings": "Impostazioni",
+      "seo": "SEO",
       "meta": "Metadati"
     },
     "buttons": {
@@ -106,6 +107,12 @@
     "meta": {
       "created": "Creato il",
       "updated": "Aggiornato il"
+    },
+    "seo": {
+      "metaTitle": "Titolo meta",
+      "metaDescription": "Descrizione meta",
+      "metaKeywords": "Parole chiave meta",
+      "canonicalUrl": "URL canonico"
     },
     "details": {
       "title": "Dettagli collezione",

--- a/packages/plugin-commerce-dashboard/src/locales/it.json
+++ b/packages/plugin-commerce-dashboard/src/locales/it.json
@@ -58,7 +58,8 @@
       "manage": "Gestisci collezioni"
     },
     "search": {
-      "placeholder": "Cerca collezioni..."
+      "placeholder": "Cerca collezioni...",
+      "minLength": "Inserisci almeno 3 caratteri per cercare."
     },
     "fields": {
       "title": "Titolo",
@@ -67,6 +68,7 @@
       "status": "Stato",
       "publishAt": "Pubblica il",
       "updatedAt": "Ultimo aggiornamento",
+      "createdAt": "Creato il",
       "actions": "Azioni",
       "slug": "Slug",
       "description": "Descrizione",
@@ -98,6 +100,17 @@
       "untitled": "Collezione senza titolo",
       "error": "Impossibile caricare le collezioni. Riprova.",
       "empty": "Nessuna collezione corrisponde ai filtri attuali."
+    },
+    "filters": {
+      "active": "{{count}} filtri attivi",
+      "clear": "Rimuovi filtri",
+      "fields": {
+        "status": "Stato",
+        "tags": "Tag",
+        "publishAt": "Pubblica il",
+        "expireAt": "Nascondi il",
+        "createdAt": "Creato il"
+      }
     },
     "status": {
       "Draft": "Bozza",

--- a/packages/plugin-commerce-dashboard/src/locales/it.json
+++ b/packages/plugin-commerce-dashboard/src/locales/it.json
@@ -54,16 +54,38 @@
   "collections": {
     "pageTitle": "Collezioni",
     "pageDescription": "Organizza i prodotti in gruppi tematici per campagne e pagine dedicate.",
-    "actions": {
-      "refresh": "Aggiorna",
-      "create": "Nuova collezione",
-      "search": "Cerca collezioni",
-      "open": "Apri dettagli",
-      "delete": "Elimina"
+    "title": {
+      "manage": "Gestisci collezioni"
     },
-    "emptyState": {
-      "title": "Nessuna collezione",
-      "description": "Crea la prima collezione per organizzare i prodotti nelle campagne e nella navigazione."
+    "search": {
+      "placeholder": "Cerca collezioni..."
+    },
+    "fields": {
+      "title": "Titolo",
+      "languages": "Lingue",
+      "tags": "Tag",
+      "status": "Stato",
+      "publishAt": "Pubblica il",
+      "updatedAt": "Ultimo aggiornamento",
+      "actions": "Azioni",
+      "slug": "Slug",
+      "description": "Descrizione",
+      "expireAt": "Nascondi il"
+    },
+    "sections": {
+      "details": "Dettagli",
+      "settings": "Impostazioni",
+      "meta": "Metadati"
+    },
+    "buttons": {
+      "add": "Aggiungi collezione",
+      "copy": "Copia",
+      "download": "Scarica",
+      "edit": "Modifica",
+      "delete": "Elimina",
+      "viewJson": "Mostra JSON",
+      "cancel": "Annulla",
+      "save": "Salva"
     },
     "table": {
       "columns": {
@@ -80,6 +102,10 @@
       "Draft": "Bozza",
       "Published": "Pubblicata",
       "Archived": "Archiviata"
+    },
+    "meta": {
+      "created": "Creato il",
+      "updated": "Aggiornato il"
     },
     "details": {
       "title": "Dettagli collezione",

--- a/packages/plugin-commerce-dashboard/src/locales/it.json
+++ b/packages/plugin-commerce-dashboard/src/locales/it.json
@@ -4,11 +4,13 @@
   },
   "menu": {
     "commerce": "E-commerce",
+    "collections": "Collezioni",
     "products": "Prodotti",
     "orders": "Ordini"
   },
   "breadcrumb": {
     "home": "Bacheca",
+    "collections": "Collezioni",
     "products": "Prodotti",
     "orders": "Ordini"
   },
@@ -47,6 +49,81 @@
         "title": "Prezzi comprensivi di tasse",
         "description": "Mostra i prezzi dei prodotti includendo le imposte per impostazione predefinita."
       }
+    }
+  },
+  "collections": {
+    "pageTitle": "Collezioni",
+    "pageDescription": "Organizza i prodotti in gruppi tematici per campagne e pagine dedicate.",
+    "actions": {
+      "refresh": "Aggiorna",
+      "create": "Nuova collezione",
+      "search": "Cerca collezioni",
+      "open": "Apri dettagli",
+      "delete": "Elimina"
+    },
+    "emptyState": {
+      "title": "Nessuna collezione",
+      "description": "Crea la prima collezione per organizzare i prodotti nelle campagne e nella navigazione."
+    },
+    "table": {
+      "columns": {
+        "name": "Nome",
+        "status": "Stato",
+        "tags": "Tag",
+        "updatedAt": "Ultimo aggiornamento"
+      },
+      "untitled": "Collezione senza titolo",
+      "error": "Impossibile caricare le collezioni. Riprova."
+    },
+    "status": {
+      "Draft": "Bozza",
+      "Published": "Pubblicata",
+      "Archived": "Archiviata"
+    },
+    "details": {
+      "title": "Dettagli collezione",
+      "description": "Configura contenuti e regole di pubblicazione per questa collezione.",
+      "breadcrumb": "Dettagli collezione",
+      "language": "Lingua",
+      "name": "Titolo",
+      "namePlaceholder": "Nome della collezione",
+      "slug": "Slug",
+      "slugPlaceholder": "slug-collezione",
+      "descriptionPlaceholder": "Descrivi lo scopo della collezione.",
+      "status": "Stato",
+      "tags": "Tag",
+      "tagPlaceholder": "Aggiungi un tag e premi invio",
+      "addTag": "Aggiungi tag",
+      "removeTag": "Rimuovi tag \"{{tag}}\"",
+      "noTags": "Nessun tag ancora presente.",
+      "publishAt": "Pubblica il",
+      "expireAt": "Nascondi il",
+      "meta": {
+        "title": "Metadati",
+        "created": "Creato il",
+        "updated": "Aggiornato il"
+      },
+      "actions": {
+        "save": "Salva collezione",
+        "cancel": "Annulla"
+      },
+      "notifications": {
+        "saved": "Collezione aggiornata con successo.",
+        "created": "Collezione creata con successo.",
+        "validationError": "Inserisci titolo e slug per la lingua selezionata.",
+        "error": "Impossibile salvare la collezione. Riprova."
+      }
+    },
+    "create": {
+      "title": "Crea collezione",
+      "description": "Imposta la prima traduzione e la disponibilità della nuova collezione.",
+      "breadcrumb": "Crea collezione"
+    },
+    "delete": {
+      "title": "Elimina collezione",
+      "description": "Questa azione è irreversibile. Confermi di voler eliminare la collezione?",
+      "confirm": "Elimina",
+      "cancel": "Annulla"
     }
   },
   "products": {

--- a/packages/plugin-commerce-dashboard/src/module.tsx
+++ b/packages/plugin-commerce-dashboard/src/module.tsx
@@ -1,10 +1,12 @@
-import { Package, ShoppingCart, Truck } from "lucide-react";
+import { Layers, Package, ShoppingCart, Truck } from "lucide-react";
 import type { DashboardModule } from "@kitejs-cms/dashboard-core";
 import { CommerceSettings } from "./components/commerce-settings";
 import { CommerceProductsPage } from "./pages/commerce-products";
 import { CommerceProductDetailsPage } from "./pages/commerce-product-details";
 import { CommerceOrdersPage } from "./pages/commerce-orders";
 import { CommerceOrderDetailsPage } from "./pages/commerce-order-details";
+import { CommerceCollectionsPage } from "./pages/commerce-collections";
+import { CommerceCollectionDetailsPage } from "./pages/commerce-collection-details";
 import { COMMERCE_PLUGIN_NAMESPACE } from "./constants";
 
 /* i18n */
@@ -30,6 +32,24 @@ export const CommerceModule: DashboardModule = {
     ],
   },
   routes: [
+    {
+      path: "commerce/collections",
+      element: <CommerceCollectionsPage />,
+      label: "commerce:menu.collections",
+      requiredPermissions: ["plugin-commerce:collections.read"],
+    },
+    {
+      path: "commerce/collections/new",
+      element: <CommerceCollectionDetailsPage />,
+      label: "",
+      requiredPermissions: ["plugin-commerce:collections.create"],
+    },
+    {
+      path: "commerce/collections/:id",
+      element: <CommerceCollectionDetailsPage />,
+      label: "",
+      requiredPermissions: ["plugin-commerce:collections.read"],
+    },
     {
       path: "commerce/products",
       element: <CommerceProductsPage />,
@@ -65,10 +85,17 @@ export const CommerceModule: DashboardModule = {
     title: "commerce:menu.commerce",
     icon: ShoppingCart,
     requiredPermissions: [
+      "plugin-commerce:collections.read",
       "plugin-commerce:products.read",
       "plugin-commerce:orders.read",
     ],
     items: [
+      {
+        url: "/commerce/collections",
+        title: "commerce:menu.collections",
+        icon: Layers,
+        requiredPermissions: ["plugin-commerce:collections.read"],
+      },
       {
         url: "/commerce/products",
         title: "commerce:menu.products",

--- a/packages/plugin-commerce-dashboard/src/pages/commerce-collection-details.tsx
+++ b/packages/plugin-commerce-dashboard/src/pages/commerce-collection-details.tsx
@@ -1,0 +1,559 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { useLocation, useNavigate, useParams } from "react-router-dom";
+import {
+  Badge,
+  Button,
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+  Input,
+  Label,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Separator,
+  Skeleton,
+  Textarea,
+  useApi,
+  useBreadcrumb,
+  useSettingsContext,
+} from "@kitejs-cms/dashboard-core";
+import { Plus, Save, X } from "lucide-react";
+import { CollectionLanguageTabs } from "../components/collection-language-tabs";
+
+interface CollectionTranslation {
+  title?: string;
+  description?: string;
+  slug?: string;
+}
+
+type CollectionStatus = "Draft" | "Published" | "Archived";
+
+interface CollectionDetail {
+  id: string;
+  status?: CollectionStatus;
+  tags?: string[];
+  publishAt?: string | null;
+  expireAt?: string | null;
+  coverImage?: string | null;
+  translations: Record<string, CollectionTranslation>;
+  slugs: Record<string, string>;
+  createdAt?: string | Date;
+  updatedAt?: string | Date;
+}
+
+function generateSlug(value: string) {
+  return value
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9\s-]/g, "")
+    .replace(/\s+/g, "-")
+    .replace(/-+/g, "-");
+}
+
+function toDateInputValue(value?: string | Date | null) {
+  if (!value) return "";
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) return "";
+  return date.toISOString().slice(0, 16);
+}
+
+function toIsoString(value: string) {
+  if (!value) return undefined;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return undefined;
+  return date.toISOString();
+}
+
+export function CommerceCollectionDetailsPage() {
+  const { id } = useParams<{ id: string }>();
+  const location = useLocation();
+  const navigate = useNavigate();
+  const { t, i18n } = useTranslation("commerce");
+  const { setBreadcrumb } = useBreadcrumb();
+  const { cmsSettings } = useSettingsContext();
+
+  const {
+    data: fetchedCollection,
+    loading: loadingCollection,
+    fetchData: fetchCollection,
+  } = useApi<CollectionDetail>();
+  const { loading: savingCollection, fetchData: upsertCollection } =
+    useApi<CollectionDetail>();
+
+  const [collection, setCollection] = useState<CollectionDetail | null>(null);
+  const [translations, setTranslations] = useState<Record<string, CollectionTranslation>>({});
+  const [activeLanguage, setActiveLanguage] = useState<string>(cmsSettings?.defaultLanguage ?? "en");
+  const [status, setStatus] = useState<CollectionStatus>("Draft");
+  const [publishAt, setPublishAt] = useState<string>("");
+  const [expireAt, setExpireAt] = useState<string>("");
+  const [tags, setTags] = useState<string[]>([]);
+  const [tagInput, setTagInput] = useState<string>("");
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const isCreating = !id || location.pathname.endsWith("/new");
+
+  const availableLanguages = useMemo(() => Object.keys(translations), [translations]);
+
+  const currentTranslation = useMemo(() => {
+    if (!activeLanguage) return { title: "", slug: "", description: "" };
+    return (
+      translations[activeLanguage] ?? {
+        title: "",
+        slug: "",
+        description: "",
+      }
+    );
+  }, [translations, activeLanguage]);
+
+  const resolveTitle = useCallback(() => {
+    const fallbackTitle = t("collections.details.breadcrumb");
+    const translation =
+      translations[activeLanguage]?.title?.trim() ||
+      translations[i18n.language]?.title?.trim() ||
+      translations[cmsSettings?.defaultLanguage ?? ""]?.title?.trim();
+    return translation || fallbackTitle;
+  }, [
+    translations,
+    activeLanguage,
+    i18n.language,
+    cmsSettings?.defaultLanguage,
+    t,
+  ]);
+
+  useEffect(() => {
+    setBreadcrumb([
+      { label: t("breadcrumb.home"), path: "/" },
+      { label: t("breadcrumb.collections"), path: "/commerce/collections" },
+      isCreating
+        ? { label: t("collections.create.breadcrumb"), path: location.pathname }
+        : { label: resolveTitle(), path: location.pathname },
+    ]);
+  }, [
+    setBreadcrumb,
+    t,
+    location.pathname,
+    isCreating,
+    resolveTitle,
+  ]);
+
+  useEffect(() => {
+    if (!isCreating && id) {
+      void fetchCollection(`commerce/collections/${id}`);
+    }
+  }, [fetchCollection, id, isCreating]);
+
+  useEffect(() => {
+    if (fetchedCollection) {
+      const data = fetchedCollection;
+      setCollection(data);
+      setStatus((data.status as CollectionStatus) ?? "Draft");
+      setTags(data.tags ?? []);
+      setPublishAt(toDateInputValue(data.publishAt));
+      setExpireAt(toDateInputValue(data.expireAt));
+
+      const normalized: Record<string, CollectionTranslation> = {};
+      Object.entries(data.translations ?? {}).forEach(([language, value]) => {
+        normalized[language] = {
+          title: value?.title ?? "",
+          description: value?.description ?? "",
+          slug:
+            value?.slug ?? data.slugs?.[language] ?? "",
+        };
+      });
+      setTranslations(normalized);
+
+      const preferredLanguage = normalized[i18n.language]
+        ? i18n.language
+        : cmsSettings?.defaultLanguage && normalized[cmsSettings.defaultLanguage]
+          ? cmsSettings.defaultLanguage
+          : Object.keys(normalized)[0] ?? cmsSettings?.defaultLanguage ?? "en";
+      setActiveLanguage(preferredLanguage);
+    }
+  }, [fetchedCollection, cmsSettings?.defaultLanguage, i18n.language]);
+
+  useEffect(() => {
+    if (isCreating && Object.keys(translations).length === 0) {
+      const defaultLanguage = cmsSettings?.defaultLanguage ?? "en";
+      setTranslations({
+        [defaultLanguage]: { title: "", slug: "", description: "" },
+      });
+      setActiveLanguage(defaultLanguage);
+      setStatus("Draft");
+      setTags([]);
+      setPublishAt("");
+      setExpireAt("");
+    }
+  }, [isCreating, cmsSettings?.defaultLanguage, translations]);
+
+  const handleAddLanguage = (language: string) => {
+    setTranslations((prev) => ({
+      ...prev,
+      [language]: { title: "", slug: "", description: "" },
+    }));
+    setActiveLanguage(language);
+  };
+
+  const handleTitleChange = (value: string) => {
+    setTranslations((prev) => {
+      const current = prev[activeLanguage] ?? { title: "", slug: "", description: "" };
+      const nextSlug = current.slug?.trim() ? current.slug : generateSlug(value);
+      return {
+        ...prev,
+        [activeLanguage]: {
+          ...current,
+          title: value,
+          slug: nextSlug,
+        },
+      };
+    });
+  };
+
+  const handleTranslationChange = <K extends keyof CollectionTranslation>(
+    field: K,
+    value: CollectionTranslation[K]
+  ) => {
+    setTranslations((prev) => ({
+      ...prev,
+      [activeLanguage]: {
+        ...(prev[activeLanguage] ?? { title: "", slug: "", description: "" }),
+        [field]: value ?? "",
+      },
+    }));
+  };
+
+  const handleAddTag = () => {
+    const next = tagInput.trim();
+    if (!next) return;
+    if (tags.includes(next)) {
+      setTagInput("");
+      return;
+    }
+    setTags((prev) => [...prev, next]);
+    setTagInput("");
+  };
+
+  const handleRemoveTag = (tag: string) => {
+    setTags((prev) => prev.filter((value) => value !== tag));
+  };
+
+  const handleSave = async () => {
+    setErrorMessage(null);
+    setSuccessMessage(null);
+
+    const translation = translations[activeLanguage];
+    if (!translation || !translation.title?.trim() || !translation.slug?.trim()) {
+      setErrorMessage(t("collections.details.notifications.validationError"));
+      return;
+    }
+
+    const payload = {
+      id: collection?.id,
+      language: activeLanguage,
+      title: translation.title.trim(),
+      slug: translation.slug.trim(),
+      description: translation.description?.trim() ?? undefined,
+      status,
+      tags,
+      publishAt: toIsoString(publishAt),
+      expireAt: toIsoString(expireAt),
+    };
+
+    const { data: savedCollection, error: saveError } = await upsertCollection(
+      "commerce/collections",
+      "POST",
+      payload
+    );
+
+    if (saveError || !savedCollection) {
+      setErrorMessage(t("collections.details.notifications.error"));
+      return;
+    }
+
+    setCollection(savedCollection);
+    setStatus((savedCollection.status as CollectionStatus) ?? status);
+    setTags(savedCollection.tags ?? []);
+    setPublishAt(toDateInputValue(savedCollection.publishAt));
+    setExpireAt(toDateInputValue(savedCollection.expireAt));
+
+    const normalized: Record<string, CollectionTranslation> = {};
+    Object.entries(savedCollection.translations ?? {}).forEach(([language, value]) => {
+      normalized[language] = {
+        title: value?.title ?? "",
+        description: value?.description ?? "",
+        slug:
+          value?.slug ?? savedCollection.slugs?.[language] ?? "",
+      };
+    });
+    setTranslations(normalized);
+
+    const preferredLanguage = normalized[activeLanguage]
+      ? activeLanguage
+      : cmsSettings?.defaultLanguage && normalized[cmsSettings.defaultLanguage]
+        ? cmsSettings.defaultLanguage
+        : Object.keys(normalized)[0] ?? activeLanguage;
+    setActiveLanguage(preferredLanguage);
+
+    const message = collection
+      ? t("collections.details.notifications.saved")
+      : t("collections.details.notifications.created");
+    setSuccessMessage(message);
+
+    if (!collection && savedCollection.id) {
+      navigate(`/commerce/collections/${savedCollection.id}`, { replace: true });
+    }
+  };
+
+  const formatDateTime = (value?: string | Date | null) => {
+    if (!value) return "-";
+    const date = value instanceof Date ? value : new Date(value);
+    if (Number.isNaN(date.getTime())) return "-";
+    try {
+      return new Intl.DateTimeFormat(i18n.language, {
+        year: "numeric",
+        month: "short",
+        day: "numeric",
+        hour: "2-digit",
+        minute: "2-digit",
+      }).format(date);
+    } catch {
+      return date.toISOString();
+    }
+  };
+
+  if (loadingCollection && !collection && !isCreating) {
+    return (
+      <div className="space-y-4">
+        <Skeleton className="h-12 w-full" />
+        <Skeleton className="h-64 w-full" />
+      </div>
+    );
+  }
+
+  const languagesForTabs = availableLanguages.length > 0 ? availableLanguages : [activeLanguage];
+
+  return (
+    <div className="space-y-6">
+      <Button variant="ghost" onClick={() => navigate(-1)} className="px-0">
+        {t("common.back")}
+      </Button>
+
+      <Card>
+        <CardHeader className="space-y-1">
+          <CardTitle>
+            {isCreating
+              ? t("collections.create.title")
+              : t("collections.details.title")}
+          </CardTitle>
+          <CardDescription>
+            {isCreating
+              ? t("collections.create.description")
+              : t("collections.details.description")}
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          {successMessage ? (
+            <div className="rounded-md border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-700">
+              {successMessage}
+            </div>
+          ) : null}
+          {errorMessage ? (
+            <div className="rounded-md border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive">
+              {errorMessage}
+            </div>
+          ) : null}
+
+          <section className="space-y-4">
+            <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+              <Label className="text-sm font-medium text-muted-foreground">
+                {t("collections.details.language")}
+              </Label>
+              <CollectionLanguageTabs
+                languages={languagesForTabs}
+                activeLanguage={activeLanguage}
+                onLanguageChange={setActiveLanguage}
+                onAddLanguage={handleAddLanguage}
+              />
+            </div>
+
+            <div className="grid gap-4 md:grid-cols-2">
+              <div className="space-y-2">
+                <Label htmlFor="collection-title">{t("collections.details.name")}</Label>
+                <Input
+                  id="collection-title"
+                  value={currentTranslation.title ?? ""}
+                  onChange={(event) => handleTitleChange(event.target.value)}
+                  placeholder={t("collections.details.namePlaceholder")}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="collection-slug">{t("collections.details.slug")}</Label>
+                <Input
+                  id="collection-slug"
+                  value={currentTranslation.slug ?? ""}
+                  onChange={(event) =>
+                    handleTranslationChange("slug", event.target.value)
+                  }
+                  placeholder={t("collections.details.slugPlaceholder")}
+                />
+              </div>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="collection-description">
+                {t("collections.details.description")}
+              </Label>
+              <Textarea
+                id="collection-description"
+                value={currentTranslation.description ?? ""}
+                onChange={(event) =>
+                  handleTranslationChange("description", event.target.value)
+                }
+                placeholder={t("collections.details.descriptionPlaceholder")}
+                rows={5}
+              />
+            </div>
+          </section>
+
+          <Separator />
+
+          <section className="grid gap-4 md:grid-cols-2">
+            <div className="space-y-2">
+              <Label>{t("collections.details.status")}</Label>
+              <Select value={status} onValueChange={(value) => setStatus(value as CollectionStatus)}>
+                <SelectTrigger>
+                  <SelectValue placeholder={t("collections.details.status") ?? undefined} />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="Draft">
+                    {t("collections.status.Draft", { defaultValue: "Draft" })}
+                  </SelectItem>
+                  <SelectItem value="Published">
+                    {t("collections.status.Published", { defaultValue: "Published" })}
+                  </SelectItem>
+                  <SelectItem value="Archived">
+                    {t("collections.status.Archived", { defaultValue: "Archived" })}
+                  </SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-2">
+              <Label>{t("collections.details.tags")}</Label>
+              <div className="flex gap-2">
+                <Input
+                  value={tagInput}
+                  onChange={(event) => setTagInput(event.target.value)}
+                  onKeyDown={(event) => {
+                    if (event.key === "Enter") {
+                      event.preventDefault();
+                      handleAddTag();
+                    }
+                  }}
+                  placeholder={t("collections.details.tagPlaceholder")}
+                />
+                <Button type="button" variant="secondary" onClick={handleAddTag} disabled={!tagInput.trim()}>
+                  <Plus className="mr-1 h-4 w-4" />
+                  {t("collections.details.addTag")}
+                </Button>
+              </div>
+              {tags.length > 0 ? (
+                <div className="flex flex-wrap gap-2">
+                  {tags.map((tag) => (
+                    <Badge key={tag} variant="outline" className="flex items-center gap-1 font-normal">
+                      {tag}
+                      <button
+                        type="button"
+                        onClick={() => handleRemoveTag(tag)}
+                        className="rounded-full focus:outline-none"
+                        aria-label={t("collections.details.removeTag", { tag })}
+                      >
+                        <X className="h-3 w-3" />
+                      </button>
+                    </Badge>
+                  ))}
+                </div>
+              ) : (
+                <p className="text-xs text-muted-foreground">
+                  {t("collections.details.noTags")}
+                </p>
+              )}
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="collection-publishAt">
+                {t("collections.details.publishAt")}
+              </Label>
+              <Input
+                id="collection-publishAt"
+                type="datetime-local"
+                value={publishAt}
+                onChange={(event) => setPublishAt(event.target.value)}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="collection-expireAt">
+                {t("collections.details.expireAt")}
+              </Label>
+              <Input
+                id="collection-expireAt"
+                type="datetime-local"
+                value={expireAt}
+                onChange={(event) => setExpireAt(event.target.value)}
+              />
+            </div>
+          </section>
+
+          {collection ? (
+            <section className="rounded-md border bg-muted/30 p-4">
+              <h3 className="text-sm font-medium text-muted-foreground">
+                {t("collections.details.meta.title")}
+              </h3>
+              <div className="mt-3 grid gap-3 md:grid-cols-2">
+                <div>
+                  <p className="text-xs text-muted-foreground uppercase">
+                    {t("collections.details.meta.created")}
+                  </p>
+                  <p className="text-sm font-medium">
+                    {formatDateTime(collection.createdAt)}
+                  </p>
+                </div>
+                <div>
+                  <p className="text-xs text-muted-foreground uppercase">
+                    {t("collections.details.meta.updated")}
+                  </p>
+                  <p className="text-sm font-medium">
+                    {formatDateTime(collection.updatedAt)}
+                  </p>
+                </div>
+              </div>
+            </section>
+          ) : null}
+
+          <div className="flex justify-end gap-3">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => navigate("/commerce/collections")}
+            >
+              {t("collections.details.actions.cancel")}
+            </Button>
+            <Button
+              type="button"
+              onClick={handleSave}
+              disabled={savingCollection}
+            >
+              <Save className="mr-2 h-4 w-4" />
+              {t("collections.details.actions.save")}
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/packages/plugin-commerce-dashboard/src/pages/commerce-collections.tsx
+++ b/packages/plugin-commerce-dashboard/src/pages/commerce-collections.tsx
@@ -17,6 +17,7 @@ import {
   CardHeader,
   CardTitle,
   DataTable,
+  LanguagesBadge,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -57,23 +58,6 @@ interface CollectionListItem {
 }
 
 const ITEMS_PER_PAGE = 10;
-
-function LanguagesBadge(translations: Record<string, unknown>) {
-  const langs = Object.keys(translations);
-  return (
-    <div className="flex items-center gap-1">
-      {langs.map((lang) => (
-        <Badge
-          key={lang}
-          variant="outline"
-          className="border-gray-200 bg-gray-50 font-normal"
-        >
-          {lang.toUpperCase()}
-        </Badge>
-      ))}
-    </div>
-  );
-}
 
 export function CommerceCollectionsPage() {
   const { t, i18n } = useTranslation("commerce");

--- a/packages/plugin-commerce-dashboard/src/pages/commerce-collections.tsx
+++ b/packages/plugin-commerce-dashboard/src/pages/commerce-collections.tsx
@@ -1,0 +1,368 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { useNavigate } from "react-router-dom";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  Badge,
+  Button,
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+  DataTable,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+  Input,
+  Skeleton,
+  useApi,
+  useBreadcrumb,
+  useDebounce,
+  useHasPermission,
+} from "@kitejs-cms/dashboard-core";
+import { MoreVertical, PenSquare, Plus, Search, Trash2 } from "lucide-react";
+
+interface CollectionTranslation {
+  title?: string;
+  description?: string;
+  slug?: string;
+}
+
+type CollectionStatus = "Draft" | "Published" | "Archived";
+
+interface CollectionListItem {
+  id: string;
+  status?: CollectionStatus;
+  tags?: string[];
+  publishAt?: string | null;
+  translations: Record<string, CollectionTranslation>;
+  updatedAt?: string;
+  createdAt?: string;
+}
+
+const ITEMS_PER_PAGE = 10;
+
+export function CommerceCollectionsPage() {
+  const { t, i18n } = useTranslation("commerce");
+  const navigate = useNavigate();
+  const { setBreadcrumb } = useBreadcrumb();
+  const { data, loading, error, fetchData, pagination } = useApi<CollectionListItem[]>();
+  const deleteApi = useApi<unknown>();
+  const hasPermission = useHasPermission();
+
+  const [page, setPage] = useState(1);
+  const [search, setSearch] = useState("");
+  const [collectionToDelete, setCollectionToDelete] = useState<CollectionListItem | null>(null);
+
+  const debouncedSearch = useDebounce(search, 400);
+
+  const canCreate = hasPermission("plugin-commerce:collections.create");
+  const canDelete = hasPermission("plugin-commerce:collections.delete");
+
+  useEffect(() => {
+    setBreadcrumb([
+      { label: t("breadcrumb.home"), path: "/" },
+      { label: t("breadcrumb.collections"), path: "/commerce/collections" },
+    ]);
+  }, [setBreadcrumb, t]);
+
+  const buildApiUrl = useCallback((pageNumber: number, searchTerm: string) => {
+    const params = new URLSearchParams();
+    params.set("page[number]", pageNumber.toString());
+    params.set("page[size]", ITEMS_PER_PAGE.toString());
+    if (searchTerm.trim().length >= 2) {
+      params.set("search", searchTerm.trim());
+    }
+    return `commerce/collections?${params.toString()}`;
+  }, []);
+
+  useEffect(() => {
+    const effectiveSearch = debouncedSearch.trim();
+    void fetchData(buildApiUrl(page, effectiveSearch));
+  }, [fetchData, page, debouncedSearch, buildApiUrl]);
+
+  const collections = data ?? [];
+
+  const handleSearchChange = (value: string) => {
+    setSearch(value);
+    setPage(1);
+  };
+
+  const handlePageChange = (nextPage: number) => {
+    setPage(nextPage);
+  };
+
+  const handleRefresh = () => {
+    const effectiveSearch = debouncedSearch.trim();
+    void fetchData(buildApiUrl(page, effectiveSearch));
+  };
+
+  const handleDelete = async () => {
+    if (!collectionToDelete) return;
+    const { error: deleteError } = await deleteApi.fetchData(
+      `commerce/collections/${collectionToDelete.id}`,
+      "DELETE"
+    );
+    if (!deleteError) {
+      setCollectionToDelete(null);
+      const effectiveSearch = debouncedSearch.trim();
+      void fetchData(buildApiUrl(page, effectiveSearch));
+    }
+  };
+
+  const formatDate = useCallback(
+    (value?: string) => {
+      if (!value) return "-";
+      try {
+        return new Intl.DateTimeFormat(i18n.language, {
+          year: "numeric",
+          month: "short",
+          day: "numeric",
+        }).format(new Date(value));
+      } catch {
+        return value;
+      }
+    },
+    [i18n.language]
+  );
+
+  const getCollectionTitle = useCallback(
+    (collection: CollectionListItem) => {
+      const translation =
+        collection.translations?.[i18n.language] ?? collection.translations?.en;
+      if (translation?.title && translation.title.trim().length > 0) {
+        return translation.title;
+      }
+      return t("collections.table.untitled");
+    },
+    [i18n.language, t]
+  );
+
+  const columns = useMemo(
+    () => [
+      {
+        key: "translations" as const,
+        label: t("collections.table.columns.name"),
+        render: (_value: unknown, row: CollectionListItem) => (
+          <div className="flex flex-col">
+            <span className="font-medium text-sm text-foreground">
+              {getCollectionTitle(row)}
+            </span>
+            {row.translations?.[i18n.language]?.slug && (
+              <span className="text-xs text-muted-foreground">
+                {row.translations[i18n.language]?.slug}
+              </span>
+            )}
+          </div>
+        ),
+      },
+      {
+        key: "status" as const,
+        label: t("collections.table.columns.status"),
+        render: (value) => {
+          const status = value as CollectionStatus | undefined;
+          return status ? (
+            <Badge variant="secondary">
+              {t(`collections.status.${status}`, { defaultValue: status })}
+            </Badge>
+          ) : (
+            <span className="text-muted-foreground">-</span>
+          );
+        },
+      },
+      {
+        key: "tags" as const,
+        label: t("collections.table.columns.tags"),
+        render: (value) => {
+          const tags = value as string[] | undefined;
+          return tags && tags.length > 0 ? (
+            <div className="flex flex-wrap gap-2">
+              {tags.slice(0, 3).map((tag) => (
+                <Badge key={tag} variant="outline" className="font-normal">
+                  {tag}
+                </Badge>
+              ))}
+              {tags.length > 3 ? (
+                <span className="text-xs text-muted-foreground">
+                  +{tags.length - 3}
+                </span>
+              ) : null}
+            </div>
+          ) : (
+            <span className="text-muted-foreground">-</span>
+          );
+        },
+      },
+      {
+        key: "updatedAt" as const,
+        label: t("collections.table.columns.updatedAt"),
+        render: (value) => (
+          <span className="text-sm text-muted-foreground">
+            {formatDate(value as string | undefined)}
+          </span>
+        ),
+      },
+      {
+        key: "id" as const,
+        label: "",
+        render: (_value, row: CollectionListItem) => (
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-8 w-8"
+                onClick={(event) => event.stopPropagation()}
+              >
+                <MoreVertical className="h-4 w-4" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <DropdownMenuItem
+                onClick={(event) => {
+                  event.stopPropagation();
+                  navigate(`/commerce/collections/${row.id}`);
+                }}
+              >
+                <PenSquare className="mr-2 h-4 w-4" />
+                {t("collections.actions.open")}
+              </DropdownMenuItem>
+              {canDelete ? (
+                <DropdownMenuItem
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    setCollectionToDelete(row);
+                  }}
+                  className="text-destructive focus:text-destructive"
+                >
+                  <Trash2 className="mr-2 h-4 w-4" />
+                  {t("collections.actions.delete")}
+                </DropdownMenuItem>
+              ) : null}
+            </DropdownMenuContent>
+          </DropdownMenu>
+        ),
+      },
+    ],
+    [
+      t,
+      i18n.language,
+      getCollectionTitle,
+      formatDate,
+      navigate,
+      canDelete,
+    ]
+  );
+
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+          <div className="space-y-1">
+            <CardTitle>{t("collections.pageTitle")}</CardTitle>
+            <CardDescription>{t("collections.pageDescription")}</CardDescription>
+          </div>
+          <div className="flex w-full flex-col gap-3 md:w-auto md:flex-row md:items-center">
+            <div className="relative md:w-64">
+              <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+              <Input
+                value={search}
+                onChange={(event) => handleSearchChange(event.target.value)}
+                placeholder={t("collections.actions.search")}
+                className="pl-9"
+              />
+            </div>
+            <div className="flex gap-2">
+              <Button variant="outline" onClick={handleRefresh} disabled={loading}>
+                {t("collections.actions.refresh")}
+              </Button>
+              {canCreate ? (
+                <Button onClick={() => navigate("/commerce/collections/new")}> 
+                  <Plus className="mr-2 h-4 w-4" />
+                  {t("collections.actions.create")}
+                </Button>
+              ) : null}
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent>
+          {error ? (
+            <div className="rounded-md border border-destructive/30 bg-destructive/10 p-4 text-sm text-destructive">
+              {t("collections.table.error")}
+            </div>
+          ) : null}
+
+          {loading ? (
+            <div className="space-y-4">
+              <Skeleton className="h-12 w-full" />
+              <Skeleton className="h-12 w-full" />
+              <Skeleton className="h-12 w-full" />
+            </div>
+          ) : collections.length === 0 ? (
+            <div className="flex flex-col items-center justify-center gap-2 py-16 text-center">
+              <h3 className="text-lg font-semibold">
+                {t("collections.emptyState.title")}
+              </h3>
+              <p className="max-w-md text-sm text-muted-foreground">
+                {t("collections.emptyState.description")}
+              </p>
+              {canCreate ? (
+                <Button onClick={() => navigate("/commerce/collections/new")}> 
+                  {t("collections.actions.create")}
+                </Button>
+              ) : null}
+            </div>
+          ) : (
+            <DataTable<CollectionListItem>
+              data={collections}
+              columns={columns}
+              isLoading={loading}
+              onRowClick={(row) => navigate(`/commerce/collections/${row.id}`)}
+              pagination=
+                {pagination
+                  ? {
+                      currentPage: pagination.currentPage,
+                      totalPages: Math.max(pagination.totalPages, 1),
+                      onPageChange: handlePageChange,
+                    }
+                  : undefined}
+            />
+          )}
+        </CardContent>
+      </Card>
+
+      <AlertDialog
+        open={collectionToDelete !== null}
+        onOpenChange={(open) => !open && setCollectionToDelete(null)}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{t("collections.delete.title")}</AlertDialogTitle>
+            <AlertDialogDescription>
+              {t("collections.delete.description")}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>{t("collections.delete.cancel")}</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleDelete}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              disabled={deleteApi.loading}
+            >
+              {t("collections.delete.confirm")}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}

--- a/packages/plugin-commerce-dashboard/src/pages/commerce-collections.tsx
+++ b/packages/plugin-commerce-dashboard/src/pages/commerce-collections.tsx
@@ -23,7 +23,6 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
   Input,
-  Skeleton,
   useApi,
   useBreadcrumb,
   useDebounce,
@@ -265,78 +264,72 @@ export function CommerceCollectionsPage() {
 
   return (
     <div className="space-y-6">
-      <Card>
-        <CardHeader className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
-          <div className="space-y-1">
-            <CardTitle>{t("collections.pageTitle")}</CardTitle>
-            <CardDescription>{t("collections.pageDescription")}</CardDescription>
+      <Card className="gap-0 overflow-hidden rounded-2xl border py-0 shadow-neutral-50">
+        <CardHeader className="rounded-t-2xl border-b border-border/60 bg-secondary py-6 text-primary">
+          <div className="flex flex-col gap-2">
+            <CardTitle className="text-lg font-semibold md:text-xl">
+              {t("collections.pageTitle")}
+            </CardTitle>
+            <CardDescription className="text-primary/80">
+              {t("collections.pageDescription")}
+            </CardDescription>
           </div>
-          <div className="flex w-full flex-col gap-3 md:w-auto md:flex-row md:items-center">
-            <div className="relative md:w-64">
-              <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-              <Input
-                value={search}
-                onChange={(event) => handleSearchChange(event.target.value)}
-                placeholder={t("collections.actions.search")}
-                className="pl-9"
-              />
+        </CardHeader>
+        <CardContent className="space-y-6 py-6">
+          <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+            <div className="flex w-full flex-col gap-3 md:flex-row md:items-center md:gap-4">
+              <div className="relative md:w-80">
+                <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+                <Input
+                  value={search}
+                  onChange={(event) => handleSearchChange(event.target.value)}
+                  placeholder={t("collections.actions.search")}
+                  className="pl-9"
+                />
+              </div>
             </div>
-            <div className="flex gap-2">
-              <Button variant="outline" onClick={handleRefresh} disabled={loading}>
+            <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+              <Button
+                variant="outline"
+                onClick={handleRefresh}
+                disabled={loading}
+                className="w-full sm:w-auto"
+              >
                 {t("collections.actions.refresh")}
               </Button>
               {canCreate ? (
-                <Button onClick={() => navigate("/commerce/collections/new")}> 
+                <Button
+                  onClick={() => navigate("/commerce/collections/new")}
+                  className="w-full sm:w-auto"
+                >
                   <Plus className="mr-2 h-4 w-4" />
                   {t("collections.actions.create")}
                 </Button>
               ) : null}
             </div>
           </div>
-        </CardHeader>
-        <CardContent>
+
           {error ? (
-            <div className="rounded-md border border-destructive/30 bg-destructive/10 p-4 text-sm text-destructive">
+            <div className="rounded-md border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive">
               {t("collections.table.error")}
             </div>
           ) : null}
 
-          {loading ? (
-            <div className="space-y-4">
-              <Skeleton className="h-12 w-full" />
-              <Skeleton className="h-12 w-full" />
-              <Skeleton className="h-12 w-full" />
-            </div>
-          ) : collections.length === 0 ? (
-            <div className="flex flex-col items-center justify-center gap-2 py-16 text-center">
-              <h3 className="text-lg font-semibold">
-                {t("collections.emptyState.title")}
-              </h3>
-              <p className="max-w-md text-sm text-muted-foreground">
-                {t("collections.emptyState.description")}
-              </p>
-              {canCreate ? (
-                <Button onClick={() => navigate("/commerce/collections/new")}> 
-                  {t("collections.actions.create")}
-                </Button>
-              ) : null}
-            </div>
-          ) : (
-            <DataTable<CollectionListItem>
-              data={collections}
-              columns={columns}
-              isLoading={loading}
-              onRowClick={(row) => navigate(`/commerce/collections/${row.id}`)}
-              pagination=
-                {pagination
-                  ? {
-                      currentPage: pagination.currentPage,
-                      totalPages: Math.max(pagination.totalPages, 1),
-                      onPageChange: handlePageChange,
-                    }
-                  : undefined}
-            />
-          )}
+          <DataTable<CollectionListItem>
+            data={collections}
+            columns={columns}
+            isLoading={loading}
+            onRowClick={(row) => navigate(`/commerce/collections/${row.id}`)}
+            pagination=
+              {pagination
+                ? {
+                    currentPage: pagination.currentPage,
+                    totalPages: Math.max(pagination.totalPages, 1),
+                    onPageChange: handlePageChange,
+                  }
+                : undefined}
+            emptyMessage={t("collections.table.empty")}
+          />
         </CardContent>
       </Card>
 


### PR DESCRIPTION
## Summary
- add language tabs component and collection list/detail pages for commerce
- register collection routes in the commerce module and surface new menu items
- localize new collection workflows in English and Italian copies

## Testing
- pnpm --filter @kitejs-cms/plugin-commerce-dashboard lint
- pnpm --filter @kitejs-cms/plugin-commerce-dashboard check-types

------
https://chatgpt.com/codex/tasks/task_e_68cdbe7384a083289bde3027c908c938