### PR TITLE
Keep products table visible without empty card

### DIFF
--- a/packages/plugin-commerce-dashboard/src/locales/en/products.json
+++ b/packages/plugin-commerce-dashboard/src/locales/en/products.json
@@ -17,7 +17,8 @@
         "currency": "Currency",
         "updatedAt": "Last updated"
       },
-      "untitled": "Untitled product"
+      "untitled": "Untitled product",
+      "empty": "No products to display"
     },
     "status": {
       "draft": "Draft",

--- a/packages/plugin-commerce-dashboard/src/locales/en/products.json
+++ b/packages/plugin-commerce-dashboard/src/locales/en/products.json
@@ -6,11 +6,59 @@
       "refresh": "Refresh",
       "create": "New product"
     },
+    "buttons": {
+      "add": "Add product",
+      "copy": "Copy",
+      "download": "Download",
+      "edit": "Edit",
+      "delete": "Delete"
+    },
+    "search": {
+      "placeholder": "Search products...",
+      "minLength": "Type at least 3 characters to search."
+    },
+    "filters": {
+      "active": "{{count}} active filters",
+      "activeView": "View: {{name}}",
+      "clear": "Clear filters",
+      "fields": {
+        "status": "Status",
+        "tags": "Tags",
+        "collection": "Collection ID",
+        "publishAt": "Publish at",
+        "expireAt": "Unpublish at",
+        "createdAt": "Created at"
+      },
+      "views": {
+        "draft": {
+          "description": "Show products that are still in draft"
+        },
+        "active": {
+          "description": "Show products that are live"
+        },
+        "archived": {
+          "description": "Show products that are archived"
+        }
+      },
+      "toasts": {
+        "viewSaved": {
+          "title": "View saved",
+          "description": "Saved \"{{name}}\" for quick reuse."
+        },
+        "viewDeleted": {
+          "title": "View deleted",
+          "description": "Removed \"{{name}}\" from your saved filters."
+        },
+        "viewSaveError": "Unable to save view. Please try again.",
+        "viewDeleteError": "Unable to delete view. Please try again."
+      }
+    },
     "emptyState": {
       "title": "No products yet",
       "description": "Start building your catalogue by creating your first product."
     },
     "table": {
+      "error": "Unable to load products. Please retry.",
       "columns": {
         "name": "Name",
         "status": "Status",
@@ -19,6 +67,16 @@
       },
       "untitled": "Untitled product",
       "empty": "No products to display"
+    },
+    "fields": {
+      "title": "Title",
+      "status": "Status",
+      "languages": "Languages",
+      "tags": "Tags",
+      "currency": "Currency",
+      "publishAt": "Publish at",
+      "updatedAt": "Updated at",
+      "actions": "Actions"
     },
     "status": {
       "draft": "Draft",
@@ -42,6 +100,12 @@
       "media": "Media",
       "galleryCount": "{{count}} assets in gallery",
       "updatedAt": "Last updated"
+    },
+    "delete": {
+      "title": "Delete product",
+      "description": "Are you sure you want to delete this product? This action cannot be undone.",
+      "cancel": "Cancel",
+      "confirm": "Delete"
     },
     "create": {
       "title": "Create product",

--- a/packages/plugin-commerce-dashboard/src/locales/it/products.json
+++ b/packages/plugin-commerce-dashboard/src/locales/it/products.json
@@ -6,11 +6,59 @@
       "refresh": "Aggiorna",
       "create": "Nuovo prodotto"
     },
+    "buttons": {
+      "add": "Aggiungi prodotto",
+      "copy": "Copia",
+      "download": "Scarica",
+      "edit": "Modifica",
+      "delete": "Elimina"
+    },
+    "search": {
+      "placeholder": "Cerca prodotti...",
+      "minLength": "Inserisci almeno 3 caratteri per cercare."
+    },
+    "filters": {
+      "active": "{{count}} filtri attivi",
+      "activeView": "Vista: {{name}}",
+      "clear": "Pulisci filtri",
+      "fields": {
+        "status": "Stato",
+        "tags": "Tag",
+        "collection": "ID collezione",
+        "publishAt": "Pubblica il",
+        "expireAt": "Depubblica il",
+        "createdAt": "Creato il"
+      },
+      "views": {
+        "draft": {
+          "description": "Mostra i prodotti ancora in bozza"
+        },
+        "active": {
+          "description": "Mostra i prodotti già online"
+        },
+        "archived": {
+          "description": "Mostra i prodotti archiviati"
+        }
+      },
+      "toasts": {
+        "viewSaved": {
+          "title": "Vista salvata",
+          "description": "\"{{name}}\" è stata salvata per un riutilizzo rapido."
+        },
+        "viewDeleted": {
+          "title": "Vista eliminata",
+          "description": "\"{{name}}\" è stata rimossa dalle viste salvate."
+        },
+        "viewSaveError": "Impossibile salvare la vista. Riprova.",
+        "viewDeleteError": "Impossibile eliminare la vista. Riprova."
+      }
+    },
     "emptyState": {
       "title": "Nessun prodotto",
       "description": "Inizia a costruire il catalogo creando il primo prodotto."
     },
     "table": {
+      "error": "Impossibile caricare i prodotti. Riprova.",
       "columns": {
         "name": "Nome",
         "status": "Stato",
@@ -19,6 +67,16 @@
       },
       "untitled": "Prodotto senza titolo",
       "empty": "Nessun prodotto da mostrare"
+    },
+    "fields": {
+      "title": "Titolo",
+      "status": "Stato",
+      "languages": "Lingue",
+      "tags": "Tag",
+      "currency": "Valuta",
+      "publishAt": "Pubblica il",
+      "updatedAt": "Aggiornato il",
+      "actions": "Azioni"
     },
     "status": {
       "draft": "Bozza",
@@ -42,6 +100,12 @@
       "media": "Media",
       "galleryCount": "{{count}} elementi in galleria",
       "updatedAt": "Ultimo aggiornamento"
+    },
+    "delete": {
+      "title": "Elimina prodotto",
+      "description": "Sei sicuro di voler eliminare questo prodotto? L'azione è irreversibile.",
+      "cancel": "Annulla",
+      "confirm": "Elimina"
     },
     "create": {
       "title": "Crea prodotto",

--- a/packages/plugin-commerce-dashboard/src/locales/it/products.json
+++ b/packages/plugin-commerce-dashboard/src/locales/it/products.json
@@ -17,7 +17,8 @@
         "currency": "Valuta",
         "updatedAt": "Ultimo aggiornamento"
       },
-      "untitled": "Prodotto senza titolo"
+      "untitled": "Prodotto senza titolo",
+      "empty": "Nessun prodotto da mostrare"
     },
     "status": {
       "draft": "Bozza",

--- a/packages/plugin-commerce-dashboard/src/modules/products/hooks/use-products-manage.tsx
+++ b/packages/plugin-commerce-dashboard/src/modules/products/hooks/use-products-manage.tsx
@@ -187,23 +187,8 @@ export function useProductsManage() {
           type: "array",
         },
         {
-          key: "collectionId",
-          label: t("products.filters.fields.collection"),
-          type: "text",
-        },
-        {
           key: "publishAt",
           label: t("products.filters.fields.publishAt"),
-          type: "date",
-        },
-        {
-          key: "expireAt",
-          label: t("products.filters.fields.expireAt"),
-          type: "date",
-        },
-        {
-          key: "createdAt",
-          label: t("products.filters.fields.createdAt"),
           type: "date",
         },
       ],
@@ -326,13 +311,9 @@ export function useProductsManage() {
       const nextViews = [...savedViews, view];
 
       try {
-        await updateSetting(
-          COMMERCE_PLUGIN_NAMESPACE,
-          PRODUCT_SETTINGS_KEY,
-          {
-            views: nextViews,
-          }
-        );
+        await updateSetting(COMMERCE_PLUGIN_NAMESPACE, PRODUCT_SETTINGS_KEY, {
+          views: nextViews,
+        });
         setSavedViews(nextViews);
         toast.success(t("products.filters.toasts.viewSaved.title"), {
           description: t("products.filters.toasts.viewSaved.description", {
@@ -357,13 +338,9 @@ export function useProductsManage() {
       const nextViews = savedViews.filter((view) => view.id !== viewId);
 
       try {
-        await updateSetting(
-          COMMERCE_PLUGIN_NAMESPACE,
-          PRODUCT_SETTINGS_KEY,
-          {
-            views: nextViews,
-          }
-        );
+        await updateSetting(COMMERCE_PLUGIN_NAMESPACE, PRODUCT_SETTINGS_KEY, {
+          views: nextViews,
+        });
         setSavedViews(nextViews);
 
         if (activeView?.id === viewId) {
@@ -506,13 +483,7 @@ export function useProductsManage() {
         label: t("products.fields.updatedAt"),
       },
     ]);
-  }, [
-    copyTable,
-    getProductTitle,
-    getStatusLabel,
-    products,
-    t,
-  ]);
+  }, [copyTable, getProductTitle, getStatusLabel, products, t]);
 
   const activeFilterCount = activeFilters.filter(
     (filter) => !isFilterValueEmpty(filter.value)

--- a/packages/plugin-commerce-dashboard/src/modules/products/hooks/use-products-manage.tsx
+++ b/packages/plugin-commerce-dashboard/src/modules/products/hooks/use-products-manage.tsx
@@ -1,0 +1,562 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { useNavigate, useSearchParams } from "react-router-dom";
+import { toast } from "sonner";
+import type { FilterCondition, FilterView } from "@kitejs-cms/core";
+import type { FilterConfig } from "@kitejs-cms/dashboard-core/components/filter-modal";
+import {
+  useApi,
+  useBreadcrumb,
+  useClipboardTable,
+  useDebounce,
+  useHasPermission,
+  useSettingsContext,
+} from "@kitejs-cms/dashboard-core";
+import { buildFilterQuery } from "@kitejs-cms/dashboard-core/lib/query-builder";
+import {
+  COMMERCE_PLUGIN_NAMESPACE,
+  PRODUCT_SETTINGS_KEY,
+} from "../../../constants";
+
+export type ProductStatus = "draft" | "active" | "archived";
+
+export interface ProductListItem {
+  id: string;
+  status?: ProductStatus;
+  tags?: string[];
+  publishAt?: string | null;
+  expireAt?: string | null;
+  translations: Record<string, Record<string, unknown>>;
+  updatedAt?: string;
+  createdAt?: string;
+  defaultCurrency?: string;
+}
+
+const ITEMS_PER_PAGE = 10;
+
+const STATUS_BADGE_STYLES: Record<ProductStatus, string> = {
+  draft: "border-yellow-700 bg-yellow-50",
+  active: "border-green-700 bg-green-50",
+  archived: "border-red-700 bg-red-50",
+};
+
+const isFilterValueEmpty = (value: unknown) => {
+  if (value === null || value === undefined || value === "") return true;
+  if (Array.isArray(value)) return value.length === 0;
+  return false;
+};
+
+interface ProductFilterSettings {
+  views?: FilterView[];
+}
+
+export function useProductsManage() {
+  const { t, i18n } = useTranslation("commerce");
+  const navigate = useNavigate();
+  const { setBreadcrumb } = useBreadcrumb();
+  const { copyTable } = useClipboardTable<ProductListItem>();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const { data, loading, error, fetchData, pagination } =
+    useApi<ProductListItem[]>();
+  const deleteApi = useApi<unknown>();
+  const hasPermission = useHasPermission();
+  const { getSetting, updateSetting } = useSettingsContext();
+
+  const [showSearch, setShowSearch] = useState(false);
+  const [productToDelete, setProductToDelete] =
+    useState<ProductListItem | null>(null);
+  const [showFilter, setShowFilter] = useState(false);
+  const [activeFilters, setActiveFilters] = useState<FilterCondition[]>([]);
+  const [activeView, setActiveView] = useState<FilterView | null>(null);
+  const [savedViews, setSavedViews] = useState<FilterView[]>([]);
+
+  const searchQuery = searchParams.get("search") || "";
+  const [searchInput, setSearchInput] = useState(searchQuery);
+  const debouncedSearch = useDebounce(searchInput, 500);
+
+  const itemsPerPage = ITEMS_PER_PAGE;
+  const currentPage = parseInt(searchParams.get("page") || "1", 10);
+  const searchParamsString = searchParams.toString();
+
+  const canCreate = hasPermission("plugin-commerce:products.create");
+  const canUpdate = hasPermission("plugin-commerce:products.update");
+  const canDelete = hasPermission("plugin-commerce:products.delete");
+
+  const effectiveSearch = useMemo(() => {
+    const trimmedSearch = debouncedSearch.trim();
+    return trimmedSearch.length >= 3 ? trimmedSearch : "";
+  }, [debouncedSearch]);
+
+  const products = useMemo(() => data ?? [], [data]);
+
+  const closeFilter = useCallback(() => {
+    setShowFilter(false);
+  }, []);
+
+  const openFilter = useCallback(() => {
+    setShowFilter(true);
+  }, []);
+
+  const toggleSearch = useCallback(() => {
+    setShowSearch((previous) => !previous);
+  }, []);
+
+  const statusFilterViews = useMemo<FilterView[]>(() => {
+    const statuses: ProductStatus[] = ["draft", "active", "archived"];
+
+    return statuses.map((key) => {
+      const descriptionKey =
+        `products.filters.views.${key}.description` as const;
+      const descriptionTranslation = t(descriptionKey);
+
+      return {
+        id: `status-${key}`,
+        name: key.toUpperCase(),
+        description:
+          descriptionTranslation !== descriptionKey
+            ? descriptionTranslation
+            : undefined,
+        conditions: [
+          {
+            id: `status-${key}`,
+            field: "status",
+            operator: "equals",
+            value: key,
+          },
+        ],
+      } satisfies FilterView;
+    });
+  }, [t]);
+
+  const lockedViewIds = useMemo(
+    () => statusFilterViews.map((view) => view.id),
+    [statusFilterViews]
+  );
+
+  useEffect(() => {
+    const loadSavedViews = async () => {
+      try {
+        const settings = await getSetting<{
+          value?: ProductFilterSettings;
+        }>(COMMERCE_PLUGIN_NAMESPACE, PRODUCT_SETTINGS_KEY);
+        setSavedViews(settings?.value?.views ?? []);
+      } catch (loadError) {
+        console.error("Failed to load product filter views", loadError);
+      }
+    };
+
+    void loadSavedViews();
+  }, [getSetting]);
+
+  const combinedViews = useMemo(
+    () => [...statusFilterViews, ...savedViews],
+    [statusFilterViews, savedViews]
+  );
+
+  useEffect(() => {
+    if (!activeView) {
+      return;
+    }
+
+    const updatedView = combinedViews.find((view) => view.id === activeView.id);
+    if (
+      updatedView &&
+      (updatedView.name !== activeView.name ||
+        updatedView.description !== activeView.description)
+    ) {
+      setActiveView(updatedView);
+    }
+  }, [activeView, combinedViews]);
+
+  const filterConfig = useMemo<FilterConfig>(
+    () => ({
+      fields: [
+        {
+          key: "status",
+          label: t("products.filters.fields.status"),
+          type: "select",
+          options: [
+            { value: "draft", label: t("products.status.draft") },
+            { value: "active", label: t("products.status.active") },
+            { value: "archived", label: t("products.status.archived") },
+          ],
+        },
+        {
+          key: "tags",
+          label: t("products.filters.fields.tags"),
+          type: "array",
+        },
+        {
+          key: "collectionId",
+          label: t("products.filters.fields.collection"),
+          type: "text",
+        },
+        {
+          key: "publishAt",
+          label: t("products.filters.fields.publishAt"),
+          type: "date",
+        },
+        {
+          key: "expireAt",
+          label: t("products.filters.fields.expireAt"),
+          type: "date",
+        },
+        {
+          key: "createdAt",
+          label: t("products.filters.fields.createdAt"),
+          type: "date",
+        },
+      ],
+      views: combinedViews,
+      allowSaveViews: true,
+      lockedViewIds,
+    }),
+    [combinedViews, lockedViewIds, t]
+  );
+
+  useEffect(() => {
+    setBreadcrumb([
+      { label: t("breadcrumb.home"), path: "/" },
+      { label: t("breadcrumb.products"), path: "/commerce/products" },
+    ]);
+  }, [setBreadcrumb, t]);
+
+  useEffect(() => {
+    setSearchInput(searchQuery);
+  }, [searchQuery]);
+
+  const apiQueryString = useMemo(() => {
+    const params = new URLSearchParams();
+    params.set("page[number]", currentPage.toString());
+    params.set("page[size]", itemsPerPage.toString());
+    if (effectiveSearch) {
+      params.set("search", effectiveSearch);
+    }
+    if (activeFilters.length > 0) {
+      const filterQuery = buildFilterQuery(activeFilters);
+      Object.entries(filterQuery).forEach(([key, value]) => {
+        if (value === undefined || value === null) {
+          return;
+        }
+        if (Array.isArray(value)) {
+          if (value.length > 0) {
+            params.set(key, value.join(","));
+          }
+        } else if (typeof value === "boolean") {
+          params.set(key, value ? "true" : "false");
+        } else {
+          params.set(key, String(value));
+        }
+      });
+    }
+
+    return params.toString();
+  }, [activeFilters, currentPage, effectiveSearch, itemsPerPage]);
+
+  useEffect(() => {
+    const params = new URLSearchParams();
+    params.set("page", currentPage.toString());
+    if (effectiveSearch) {
+      params.set("search", effectiveSearch);
+    }
+    const newParams = params.toString();
+    if (searchParamsString !== newParams) {
+      setSearchParams(params, { replace: true });
+    }
+
+    void fetchData(`commerce/products?${apiQueryString}`);
+  }, [
+    apiQueryString,
+    currentPage,
+    effectiveSearch,
+    fetchData,
+    searchParamsString,
+    setSearchParams,
+  ]);
+
+  const handleSearchChange = useCallback(
+    (value: string) => {
+      setSearchInput(value);
+      if (currentPage !== 1) {
+        const params = new URLSearchParams(searchParams);
+        params.set("page", "1");
+        setSearchParams(params);
+      }
+    },
+    [currentPage, searchParams, setSearchParams]
+  );
+
+  const handleApplyFilters = useCallback(
+    (filters: FilterCondition[]) => {
+      setActiveFilters(filters);
+      setActiveView(null);
+      closeFilter();
+
+      if (currentPage !== 1) {
+        const params = new URLSearchParams(searchParams);
+        params.set("page", "1");
+        setSearchParams(params);
+      }
+    },
+    [closeFilter, currentPage, searchParams, setSearchParams]
+  );
+
+  const handleLoadView = useCallback(
+    (view: FilterView) => {
+      setActiveFilters(
+        view.conditions.map((condition) => ({
+          ...condition,
+          value: Array.isArray(condition.value)
+            ? [...condition.value]
+            : condition.value,
+        }))
+      );
+      setActiveView(view);
+      closeFilter();
+
+      const params = new URLSearchParams(searchParams);
+      params.set("page", "1");
+      setSearchParams(params);
+    },
+    [closeFilter, searchParams, setSearchParams]
+  );
+
+  const handleSaveView = useCallback(
+    async (view: FilterView) => {
+      const nextViews = [...savedViews, view];
+
+      try {
+        await updateSetting(
+          COMMERCE_PLUGIN_NAMESPACE,
+          PRODUCT_SETTINGS_KEY,
+          {
+            views: nextViews,
+          }
+        );
+        setSavedViews(nextViews);
+        toast.success(t("products.filters.toasts.viewSaved.title"), {
+          description: t("products.filters.toasts.viewSaved.description", {
+            name: view.name,
+          }),
+        });
+      } catch (saveError) {
+        console.error("Failed to save product filter view", saveError);
+        toast.error(t("products.filters.toasts.viewSaveError"));
+      }
+    },
+    [savedViews, t, updateSetting]
+  );
+
+  const handleDeleteView = useCallback(
+    async (viewId: string) => {
+      const viewToDelete = savedViews.find((view) => view.id === viewId);
+      if (!viewToDelete) {
+        return;
+      }
+
+      const nextViews = savedViews.filter((view) => view.id !== viewId);
+
+      try {
+        await updateSetting(
+          COMMERCE_PLUGIN_NAMESPACE,
+          PRODUCT_SETTINGS_KEY,
+          {
+            views: nextViews,
+          }
+        );
+        setSavedViews(nextViews);
+
+        if (activeView?.id === viewId) {
+          setActiveView(null);
+          setActiveFilters([]);
+        }
+
+        toast.success(t("products.filters.toasts.viewDeleted.title"), {
+          description: t("products.filters.toasts.viewDeleted.description", {
+            name: viewToDelete.name,
+          }),
+        });
+      } catch (deleteError) {
+        console.error("Failed to delete product filter view", deleteError);
+        toast.error(t("products.filters.toasts.viewDeleteError"));
+      }
+    },
+    [activeView, savedViews, t, updateSetting]
+  );
+
+  const handleClearFilters = useCallback(() => {
+    setActiveFilters([]);
+    setActiveView(null);
+    const params = new URLSearchParams(searchParams);
+    params.set("page", "1");
+    setSearchParams(params);
+  }, [searchParams, setSearchParams]);
+
+  const handlePageChange = useCallback(
+    (page: number) => {
+      const params = new URLSearchParams(searchParams);
+      params.set("page", page.toString());
+      setSearchParams(params);
+    },
+    [searchParams, setSearchParams]
+  );
+
+  const handleRowClick = useCallback(
+    (id: string) => {
+      navigate(`/commerce/products/${id}`);
+    },
+    [navigate]
+  );
+
+  const handleCreate = useCallback(() => {
+    navigate("/commerce/products/new");
+  }, [navigate]);
+
+  const requestDelete = useCallback((product: ProductListItem) => {
+    setProductToDelete(product);
+  }, []);
+
+  const cancelDelete = useCallback(() => {
+    setProductToDelete(null);
+  }, []);
+
+  const confirmDelete = useCallback(async () => {
+    if (!productToDelete) return;
+    const { error: deleteError } = await deleteApi.fetchData(
+      `commerce/products/${productToDelete.id}`,
+      "DELETE"
+    );
+    if (!deleteError) {
+      setProductToDelete(null);
+      await fetchData(`commerce/products?${apiQueryString}`);
+    }
+  }, [apiQueryString, deleteApi, fetchData, productToDelete]);
+
+  const getProductTitle = useCallback(
+    (product: ProductListItem) => {
+      const translation =
+        product.translations?.[i18n.language] ?? product.translations?.en;
+      if (
+        translation &&
+        typeof translation.title === "string" &&
+        translation.title.trim().length > 0
+      ) {
+        return translation.title as string;
+      }
+      return t("products.table.untitled");
+    },
+    [i18n.language, t]
+  );
+
+  const getStatusLabel = useCallback(
+    (status?: ProductStatus) => {
+      if (!status) return "-";
+      const key = `products.status.${status}` as const;
+      const label = t(key);
+      return label === key ? status : label;
+    },
+    [t]
+  );
+
+  const formatDate = useCallback(
+    (value?: string | null) => {
+      if (!value) return "-";
+      try {
+        return new Intl.DateTimeFormat(i18n.language, {
+          dateStyle: "medium",
+          timeStyle: "short",
+        }).format(new Date(value));
+      } catch {
+        return value;
+      }
+    },
+    [i18n.language]
+  );
+
+  const handleCopy = useCallback(() => {
+    if (!products.length) return;
+    const dataset = products.map((row) => ({
+      ...row,
+      titleForClipboard: getProductTitle(row),
+      languagesForClipboard: Object.keys(row.translations).join(", "),
+      tagsForClipboard: row.tags?.length ? row.tags.join(", ") : "-",
+      statusForClipboard: getStatusLabel(row.status),
+      publishAtForClipboard: row.publishAt
+        ? new Date(row.publishAt).toISOString()
+        : "-",
+      updatedAtForClipboard: row.updatedAt
+        ? new Date(row.updatedAt).toISOString()
+        : "-",
+    }));
+
+    copyTable(dataset, [
+      { key: "titleForClipboard", label: t("products.fields.title") },
+      {
+        key: "languagesForClipboard",
+        label: t("products.fields.languages"),
+      },
+      { key: "tagsForClipboard", label: t("products.fields.tags") },
+      { key: "statusForClipboard", label: t("products.fields.status") },
+      {
+        key: "publishAtForClipboard",
+        label: t("products.fields.publishAt"),
+      },
+      {
+        key: "updatedAtForClipboard",
+        label: t("products.fields.updatedAt"),
+      },
+    ]);
+  }, [
+    copyTable,
+    getProductTitle,
+    getStatusLabel,
+    products,
+    t,
+  ]);
+
+  const activeFilterCount = activeFilters.filter(
+    (filter) => !isFilterValueEmpty(filter.value)
+  ).length;
+  const hasActiveFilters = activeFilterCount > 0;
+
+  return {
+    t,
+    products,
+    loading,
+    error,
+    pagination,
+    showSearch,
+    toggleSearch,
+    searchInput,
+    handleSearchChange,
+    showFilter,
+    openFilter,
+    closeFilter,
+    filterConfig,
+    activeFilters,
+    activeFilterCount,
+    hasActiveFilters,
+    activeView,
+    handleApplyFilters,
+    handleLoadView,
+    handleSaveView,
+    handleDeleteView,
+    handleClearFilters,
+    canCreate,
+    canUpdate,
+    canDelete,
+    handleCopy,
+    handlePageChange,
+    handleRowClick,
+    handleCreate,
+    requestDelete,
+    cancelDelete,
+    confirmDelete,
+    deleteLoading: deleteApi.loading,
+    productToDelete,
+    getProductTitle,
+    getStatusLabel,
+    statusBadgeStyles: STATUS_BADGE_STYLES,
+    formatDate,
+  };
+}

--- a/packages/plugin-commerce-dashboard/src/modules/products/pages/products-manage.tsx
+++ b/packages/plugin-commerce-dashboard/src/modules/products/pages/products-manage.tsx
@@ -104,20 +104,6 @@ export function CommerceProductsPage() {
               <Skeleton className="h-12 w-full" />
               <Skeleton className="h-12 w-full" />
             </div>
-          ) : products.length === 0 ? (
-            <div className="flex flex-col items-center justify-center gap-2 py-12 text-center">
-              <h3 className="text-lg font-semibold">
-                {t("products.emptyState.title")}
-              </h3>
-              <p className="max-w-lg text-sm text-muted-foreground">
-                {t("products.emptyState.description")}
-              </p>
-              {canCreate ? (
-                <Button onClick={() => navigate("/commerce/products/new")}>
-                  {t("products.actions.create")}
-                </Button>
-              ) : null}
-            </div>
           ) : (
             <Table>
               <TableHeader>
@@ -129,30 +115,41 @@ export function CommerceProductsPage() {
                 </TableRow>
               </TableHeader>
               <TableBody>
-                {products.map((product) => (
-                  <TableRow
-                    key={product.id}
-                    className="cursor-pointer hover:bg-muted/50"
-                    onClick={() => navigate(`/commerce/products/${product.id}`)}
-                  >
-                    <TableCell className="font-medium">
-                      {getProductTitle(product)}
+                {products.length === 0 ? (
+                  <TableRow>
+                    <TableCell
+                      colSpan={4}
+                      className="h-24 text-center text-sm text-muted-foreground"
+                    >
+                      {t("products.table.empty")}
                     </TableCell>
-                    <TableCell>
-                      {product.status ? (
-                        <Badge variant="secondary">
-                          {t(`products.status.${product.status}`, {
-                            defaultValue: product.status,
-                          })}
-                        </Badge>
-                      ) : (
-                        <span className="text-muted-foreground">-</span>
-                      )}
-                    </TableCell>
-                    <TableCell>{product.defaultCurrency ?? "-"}</TableCell>
-                    <TableCell>{formatDate(product.updatedAt)}</TableCell>
                   </TableRow>
-                ))}
+                ) : (
+                  products.map((product) => (
+                    <TableRow
+                      key={product.id}
+                      className="cursor-pointer hover:bg-muted/50"
+                      onClick={() => navigate(`/commerce/products/${product.id}`)}
+                    >
+                      <TableCell className="font-medium">
+                        {getProductTitle(product)}
+                      </TableCell>
+                      <TableCell>
+                        {product.status ? (
+                          <Badge variant="secondary">
+                            {t(`products.status.${product.status}`, {
+                              defaultValue: product.status,
+                            })}
+                          </Badge>
+                        ) : (
+                          <span className="text-muted-foreground">-</span>
+                        )}
+                      </TableCell>
+                      <TableCell>{product.defaultCurrency ?? "-"}</TableCell>
+                      <TableCell>{formatDate(product.updatedAt)}</TableCell>
+                    </TableRow>
+                  ))
+                )}
               </TableBody>
             </Table>
           )}

--- a/packages/plugin-commerce-dashboard/src/modules/products/pages/products-manage.tsx
+++ b/packages/plugin-commerce-dashboard/src/modules/products/pages/products-manage.tsx
@@ -1,156 +1,378 @@
-import { useEffect } from "react";
-import { useTranslation } from "react-i18next";
-import { useNavigate } from "react-router-dom";
 import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
   Badge,
   Button,
   Card,
   CardContent,
   CardHeader,
   CardTitle,
+  DataTable,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+  FilterModal,
+  Input,
+  LanguagesBadge,
   Separator,
-  Skeleton,
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-  useApi,
-  useBreadcrumb,
-  useHasPermission,
 } from "@kitejs-cms/dashboard-core";
+import {
+  Clipboard,
+  Download,
+  Edit,
+  ListFilter,
+  MoreVertical,
+  Plus,
+  Search,
+  Trash,
+  Trash2,
+} from "lucide-react";
+import {
+  type ProductListItem,
+  type ProductStatus,
+  useProductsManage,
+} from "../hooks/use-products-manage";
 
-interface ProductListItem {
-  id: string;
-  status?: string;
-  tags?: string[];
-  defaultCurrency?: string;
-  publishAt?: string | null;
-  translations: Record<string, Record<string, unknown>>;
-  updatedAt?: string;
-}
+const renderTags = (tags: string[] | undefined) => {
+  if (!tags || tags.length === 0) {
+    return <span className="text-muted-foreground">-</span>;
+  }
+
+  const maxShow = 2;
+  const visible = tags.slice(0, maxShow);
+  const extra = tags.length - maxShow;
+
+  return (
+    <div className="flex items-center gap-1">
+      {visible.map((tag) => (
+        <Badge
+          key={tag}
+          variant="outline"
+          className="border-gray-200 bg-gray-50 font-normal"
+        >
+          {tag}
+        </Badge>
+      ))}
+      {extra > 0 && (
+        <Badge
+          variant="outline"
+          className="border-gray-200 bg-gray-50 font-normal"
+        >
+          +{extra}
+        </Badge>
+      )}
+    </div>
+  );
+};
+
+const renderStatus = (
+  status: ProductStatus | undefined,
+  getStatusLabel: (status?: ProductStatus) => string,
+  statusBadgeStyles: Record<ProductStatus, string>
+) => {
+  if (!status) {
+    return <span className="text-muted-foreground">-</span>;
+  }
+
+  const badgeClasses = statusBadgeStyles[status] || "border-gray-200 bg-gray-50";
+
+  return (
+    <Badge variant="outline" className={`${badgeClasses} font-normal`}>
+      {getStatusLabel(status)}
+    </Badge>
+  );
+};
 
 export function CommerceProductsPage() {
-  const { t, i18n } = useTranslation("commerce");
-  const navigate = useNavigate();
-  const { setBreadcrumb } = useBreadcrumb();
-  const { data, loading, fetchData } = useApi<ProductListItem[]>();
-  const hasPermission = useHasPermission();
-  const canCreate = hasPermission("plugin-commerce:products.create");
-
-  useEffect(() => {
-    setBreadcrumb([
-      { label: t("breadcrumb.home"), path: "/" },
-      { label: t("breadcrumb.products"), path: "/commerce/products" },
-    ]);
-  }, [setBreadcrumb, t]);
-
-  useEffect(() => {
-    void fetchData("commerce/products");
-  }, [fetchData]);
-
-  const products = data ?? [];
-
-  const getProductTitle = (product: ProductListItem) => {
-    const language = i18n.language || "en";
-    const translation = product.translations?.[language] ?? product.translations?.en;
-    if (translation && typeof translation.title === "string") {
-      return translation.title as string;
-    }
-    return t("products.table.untitled");
-  };
-
-  const formatDate = (value?: string | null) => {
-    if (!value) return "-";
-    try {
-      return new Intl.DateTimeFormat(i18n.language, {
-        year: "numeric",
-        month: "short",
-        day: "numeric",
-      }).format(new Date(value));
-    } catch {
-      return value;
-    }
-  };
+  const {
+    t,
+    products,
+    loading,
+    error,
+    pagination,
+    showSearch,
+    toggleSearch,
+    searchInput,
+    handleSearchChange,
+    showFilter,
+    openFilter,
+    closeFilter,
+    filterConfig,
+    activeFilters,
+    activeFilterCount,
+    hasActiveFilters,
+    activeView,
+    handleApplyFilters,
+    handleLoadView,
+    handleSaveView,
+    handleDeleteView,
+    handleClearFilters,
+    canCreate,
+    canUpdate,
+    canDelete,
+    handleCopy,
+    handlePageChange,
+    handleRowClick,
+    handleCreate,
+    requestDelete,
+    cancelDelete,
+    confirmDelete,
+    deleteLoading,
+    productToDelete,
+    getProductTitle,
+    getStatusLabel,
+    statusBadgeStyles,
+    formatDate,
+  } = useProductsManage();
 
   return (
     <div className="flex flex-col items-center justify-center p-4">
       <Card className="w-full gap-0 py-0 shadow-neutral-50">
         <CardHeader className="rounded-t-xl bg-secondary py-4 text-primary">
           <div className="flex items-center justify-between">
-            <div className="flex flex-col gap-1">
+            <div className="flex flex-col gap-2">
               <CardTitle>{t("products.pageTitle")}</CardTitle>
+              {(hasActiveFilters || activeView) && (
+                <div className="flex flex-wrap items-center gap-2">
+                  {hasActiveFilters && (
+                    <Badge
+                      variant="secondary"
+                      className="w-fit bg-blue-100 text-blue-800"
+                    >
+                      {t("products.filters.active", {
+                        count: activeFilterCount,
+                      })}
+                    </Badge>
+                  )}
+                  {activeView && (
+                    <Badge
+                      variant="outline"
+                      className="w-fit border-green-300 bg-green-100 text-green-800"
+                    >
+                      {t("products.filters.activeView", {
+                        name: activeView.name,
+                      })}
+                    </Badge>
+                  )}
+                </div>
+              )}
               <p className="text-sm text-primary/70">
                 {t("products.pageDescription")}
               </p>
             </div>
-            {canCreate ? (
-              <Button onClick={() => navigate("/commerce/products/new")}>
-                {t("products.actions.create")}
+            <div className="flex items-center gap-2">
+              <Button
+                variant={hasActiveFilters ? "default" : "outline"}
+                size="icon"
+                className="cursor-pointer shadow-none"
+                onClick={openFilter}
+              >
+                <ListFilter className="h-4 w-4" />
               </Button>
-            ) : null}
+              <Button
+                variant="outline"
+                size="icon"
+                className="cursor-pointer bg-neutral-100 shadow-none"
+                onClick={toggleSearch}
+              >
+                <Search className="h-4 w-4 text-neutral-500" />
+              </Button>
+              {showSearch && (
+                <div className="origin-right transform transition-all duration-500 ease-in-out">
+                  <Input
+                    type="text"
+                    placeholder={t("products.search.placeholder")}
+                    className="w-[200px] animate-in fade-in slide-in-from-right-1 duration-300 bg-white shadow-muted"
+                    value={searchInput}
+                    onChange={(event) => handleSearchChange(event.target.value)}
+                  />
+                  {searchInput.length > 0 && searchInput.trim().length < 3 && (
+                    <p className="mt-1 text-xs text-muted-foreground">
+                      {t("products.search.minLength")}
+                    </p>
+                  )}
+                </div>
+              )}
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button variant="ghost" size="icon">
+                    <MoreVertical className="h-4 w-4" />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end">
+                  {canCreate && (
+                    <DropdownMenuItem onClick={handleCreate}>
+                      <Plus className="mr-2 h-4 w-4" />
+                      {t("products.buttons.add")}
+                    </DropdownMenuItem>
+                  )}
+                  <DropdownMenuItem onClick={handleCopy}>
+                    <Clipboard className="mr-2 h-4 w-4" />
+                    {t("products.buttons.copy")}
+                  </DropdownMenuItem>
+                  <DropdownMenuItem
+                    onClick={() => console.log(t("products.buttons.download"))}
+                  >
+                    <Download className="mr-2 h-4 w-4" />
+                    {t("products.buttons.download")}
+                  </DropdownMenuItem>
+                  {hasActiveFilters && (
+                    <DropdownMenuItem onClick={handleClearFilters}>
+                      <Trash className="mr-2 h-4 w-4" />
+                      {t("products.filters.clear")}
+                    </DropdownMenuItem>
+                  )}
+                </DropdownMenuContent>
+              </DropdownMenu>
+            </div>
           </div>
         </CardHeader>
         <Separator />
-        <CardContent className="p-0">
-          {loading ? (
-            <div className="space-y-2 p-4">
-              <Skeleton className="h-12 w-full" />
-              <Skeleton className="h-12 w-full" />
-              <Skeleton className="h-12 w-full" />
+        <CardContent className="p-0 text-sm">
+          {error && (
+            <div className="px-4 py-3 text-sm text-destructive">
+              {t("products.table.error")}
             </div>
-          ) : (
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead>{t("products.table.columns.name")}</TableHead>
-                  <TableHead>{t("products.table.columns.status")}</TableHead>
-                  <TableHead>{t("products.table.columns.currency")}</TableHead>
-                  <TableHead>{t("products.table.columns.updatedAt")}</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {products.length === 0 ? (
-                  <TableRow>
-                    <TableCell
-                      colSpan={4}
-                      className="h-24 text-center text-sm text-muted-foreground"
-                    >
-                      {t("products.table.empty")}
-                    </TableCell>
-                  </TableRow>
-                ) : (
-                  products.map((product) => (
-                    <TableRow
-                      key={product.id}
-                      className="cursor-pointer hover:bg-muted/50"
-                      onClick={() => navigate(`/commerce/products/${product.id}`)}
-                    >
-                      <TableCell className="font-medium">
-                        {getProductTitle(product)}
-                      </TableCell>
-                      <TableCell>
-                        {product.status ? (
-                          <Badge variant="secondary">
-                            {t(`products.status.${product.status}`, {
-                              defaultValue: product.status,
-                            })}
-                          </Badge>
-                        ) : (
-                          <span className="text-muted-foreground">-</span>
-                        )}
-                      </TableCell>
-                      <TableCell>{product.defaultCurrency ?? "-"}</TableCell>
-                      <TableCell>{formatDate(product.updatedAt)}</TableCell>
-                    </TableRow>
-                  ))
-                )}
-              </TableBody>
-            </Table>
           )}
+          <DataTable<ProductListItem>
+            data={products}
+            isLoading={loading}
+            columns={[
+              {
+                key: "translations" as never,
+                label: t("products.fields.title"),
+                render: (_, row) => getProductTitle(row),
+              },
+              {
+                key: "status" as never,
+                label: t("products.fields.status"),
+                render: (_, row) =>
+                  renderStatus(row.status, getStatusLabel, statusBadgeStyles),
+              },
+              {
+                key: "translations" as never,
+                label: t("products.fields.languages"),
+                render: (_, row) => LanguagesBadge(row.translations),
+              },
+              {
+                key: "tags" as never,
+                label: t("products.fields.tags"),
+                render: (_, row) => renderTags(row.tags),
+              },
+              {
+                key: "defaultCurrency" as never,
+                label: t("products.fields.currency"),
+                render: (value) => {
+                  const currency = value as string | null | undefined;
+                  return currency ?? "-";
+                },
+              },
+              {
+                key: "publishAt" as never,
+                label: t("products.fields.publishAt"),
+                render: (value) => formatDate(value as string | null | undefined),
+              },
+              {
+                key: "updatedAt" as never,
+                label: t("products.fields.updatedAt"),
+                render: (value) => formatDate(value as string | null | undefined),
+              },
+              {
+                key: "id" as never,
+                label: t("products.fields.actions"),
+                render: (_, row) => {
+                  if (!canUpdate && !canDelete) return null;
+                  return (
+                    <DropdownMenu>
+                      <DropdownMenuTrigger asChild>
+                        <Button variant="outline" size="icon" className="shadow-none">
+                          <MoreVertical />
+                        </Button>
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent align="end">
+                        {canUpdate && (
+                          <DropdownMenuItem
+                            onClick={(event) => {
+                              event.stopPropagation();
+                              handleRowClick(row.id);
+                            }}
+                          >
+                            <Edit className="mr-2 h-4 w-4" />
+                            {t("products.buttons.edit")}
+                          </DropdownMenuItem>
+                        )}
+                        {canDelete && (
+                          <DropdownMenuItem
+                            onClick={(event) => {
+                              event.stopPropagation();
+                              requestDelete(row);
+                            }}
+                            className="text-destructive focus:text-destructive"
+                          >
+                            <Trash2 className="mr-2 h-4 w-4" />
+                            {t("products.buttons.delete")}
+                          </DropdownMenuItem>
+                        )}
+                      </DropdownMenuContent>
+                    </DropdownMenu>
+                  );
+                },
+              },
+            ]}
+            pagination={{
+              currentPage: pagination?.currentPage,
+              totalPages: pagination?.totalPages,
+              onPageChange: handlePageChange,
+            }}
+            onRowClick={(row) => handleRowClick(row.id)}
+            emptyMessage={t("products.table.empty")}
+          />
         </CardContent>
       </Card>
+
+      <AlertDialog
+        open={productToDelete !== null}
+        onOpenChange={(open) => !open && cancelDelete()}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{t("products.delete.title")}</AlertDialogTitle>
+            <AlertDialogDescription>
+              {t("products.delete.description")}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>{t("products.delete.cancel")}</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => {
+                void confirmDelete();
+              }}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              disabled={deleteLoading}
+            >
+              {t("products.delete.confirm")}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      <FilterModal
+        isOpen={showFilter}
+        onClose={closeFilter}
+        config={filterConfig}
+        initialConditions={activeFilters}
+        onApplyFilters={handleApplyFilters}
+        onLoadView={handleLoadView}
+        onSaveView={handleSaveView}
+        onDeleteView={handleDeleteView}
+      />
     </div>
   );
 }

--- a/packages/plugin-commerce-dashboard/src/modules/products/pages/products-manage.tsx
+++ b/packages/plugin-commerce-dashboard/src/modules/products/pages/products-manage.tsx
@@ -81,7 +81,8 @@ const renderStatus = (
     return <span className="text-muted-foreground">-</span>;
   }
 
-  const badgeClasses = statusBadgeStyles[status] || "border-gray-200 bg-gray-50";
+  const badgeClasses =
+    statusBadgeStyles[status] || "border-gray-200 bg-gray-50";
 
   return (
     <Badge variant="outline" className={`${badgeClasses} font-normal`}>
@@ -267,22 +268,10 @@ export function CommerceProductsPage() {
                 render: (_, row) => renderTags(row.tags),
               },
               {
-                key: "defaultCurrency" as never,
-                label: t("products.fields.currency"),
-                render: (value) => {
-                  const currency = value as string | null | undefined;
-                  return currency ?? "-";
-                },
-              },
-              {
                 key: "publishAt" as never,
                 label: t("products.fields.publishAt"),
-                render: (value) => formatDate(value as string | null | undefined),
-              },
-              {
-                key: "updatedAt" as never,
-                label: t("products.fields.updatedAt"),
-                render: (value) => formatDate(value as string | null | undefined),
+                render: (value) =>
+                  formatDate(value as string | null | undefined),
               },
               {
                 key: "id" as never,
@@ -292,7 +281,11 @@ export function CommerceProductsPage() {
                   return (
                     <DropdownMenu>
                       <DropdownMenuTrigger asChild>
-                        <Button variant="outline" size="icon" className="shadow-none">
+                        <Button
+                          variant="outline"
+                          size="icon"
+                          className="shadow-none"
+                        >
                           <MoreVertical />
                         </Button>
                       </DropdownMenuTrigger>

--- a/packages/plugin-commerce-dashboard/src/modules/products/pages/products-manage.tsx
+++ b/packages/plugin-commerce-dashboard/src/modules/products/pages/products-manage.tsx
@@ -6,9 +6,9 @@ import {
   Button,
   Card,
   CardContent,
-  CardDescription,
   CardHeader,
   CardTitle,
+  Separator,
   Skeleton,
   Table,
   TableBody,
@@ -75,21 +75,16 @@ export function CommerceProductsPage() {
   };
 
   return (
-    <div className="space-y-6">
-      <Card>
-        <CardHeader className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
-          <div className="space-y-1">
-            <CardTitle>{t("products.pageTitle")}</CardTitle>
-            <CardDescription>{t("products.pageDescription")}</CardDescription>
-          </div>
-          <div className="flex gap-2">
-            <Button
-              variant="outline"
-              onClick={() => fetchData("commerce/products")}
-              disabled={loading}
-            >
-              {t("products.actions.refresh")}
-            </Button>
+    <div className="flex flex-col items-center justify-center p-4">
+      <Card className="w-full gap-0 py-0 shadow-neutral-50">
+        <CardHeader className="rounded-t-xl bg-secondary py-4 text-primary">
+          <div className="flex items-center justify-between">
+            <div className="flex flex-col gap-1">
+              <CardTitle>{t("products.pageTitle")}</CardTitle>
+              <p className="text-sm text-primary/70">
+                {t("products.pageDescription")}
+              </p>
+            </div>
             {canCreate ? (
               <Button onClick={() => navigate("/commerce/products/new")}>
                 {t("products.actions.create")}
@@ -97,9 +92,10 @@ export function CommerceProductsPage() {
             ) : null}
           </div>
         </CardHeader>
-        <CardContent>
+        <Separator />
+        <CardContent className="p-0">
           {loading ? (
-            <div className="space-y-4">
+            <div className="space-y-2 p-4">
               <Skeleton className="h-12 w-full" />
               <Skeleton className="h-12 w-full" />
               <Skeleton className="h-12 w-full" />


### PR DESCRIPTION
## Summary
- render an inline empty state inside the products table instead of replacing it with a card
- add English and Italian translations for the new empty-table message

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dae88ea1608328985f6f531e3871b0