### PR TITLE
Align commerce status badges with dashboard styles

### DIFF
--- a/packages/plugin-commerce-dashboard/src/locales/en/products/status.json
+++ b/packages/plugin-commerce-dashboard/src/locales/en/products/status.json
@@ -1,5 +1,6 @@
 {
   "draft": "Draft",
   "active": "Active",
-  "archived": "Archived"
+  "archived": "Archived",
+  "published": "Published"
 }

--- a/packages/plugin-commerce-dashboard/src/locales/it/products/status.json
+++ b/packages/plugin-commerce-dashboard/src/locales/it/products/status.json
@@ -1,5 +1,6 @@
 {
   "draft": "Bozza",
   "active": "Attivo",
-  "archived": "Archiviato"
+  "archived": "Archiviato",
+  "published": "Pubblicato"
 }

--- a/packages/plugin-commerce-dashboard/src/modules/collections/hooks/use-collections-manage.tsx
+++ b/packages/plugin-commerce-dashboard/src/modules/collections/hooks/use-collections-manage.tsx
@@ -38,11 +38,14 @@ export interface CollectionListItem {
 
 const ITEMS_PER_PAGE = 10;
 
-const STATUS_BADGE_STYLES: Record<CollectionStatus, string> = {
-  Draft: "border-yellow-700 bg-yellow-50",
-  Published: "border-green-700 bg-green-50",
-  Archived: "border-red-700 bg-red-50",
-};
+const STATUS_BADGE_STYLES = {
+  Draft: "border-yellow-700 bg-yellow-50 text-yellow-800",
+  draft: "border-yellow-700 bg-yellow-50 text-yellow-800",
+  Published: "border-green-700 bg-green-50 text-green-800",
+  published: "border-green-700 bg-green-50 text-green-800",
+  Archived: "border-red-700 bg-red-50 text-red-800",
+  archived: "border-red-700 bg-red-50 text-red-800",
+} as const satisfies Record<string, string>;
 
 const isFilterValueEmpty = (value: unknown) => {
   if (value === null || value === undefined || value === "") return true;
@@ -452,9 +455,12 @@ export function useCollectionsManage() {
   );
 
   const getStatusLabel = useCallback(
-    (status?: CollectionStatus) => {
+    (status?: string) => {
       if (!status) return "-";
-      return t(`collections.status.${status}` as const);
+      const capitalized =
+        status.charAt(0).toUpperCase() + status.slice(1).toLowerCase();
+      const key = `collections.status.${capitalized}`;
+      return t(key, { defaultValue: capitalized });
     },
     [t]
   );

--- a/packages/plugin-commerce-dashboard/src/modules/collections/pages/collections-manage.tsx
+++ b/packages/plugin-commerce-dashboard/src/modules/collections/pages/collections-manage.tsx
@@ -36,7 +36,6 @@ import {
 } from "lucide-react";
 import {
   type CollectionListItem,
-  type CollectionStatus,
   useCollectionsManage,
 } from "../hooks/use-collections-manage";
 
@@ -73,22 +72,26 @@ const renderTags = (tags: string[] | undefined) => {
 };
 
 const renderStatus = (
-  status: CollectionStatus | undefined,
-  getStatusLabel: (status?: CollectionStatus) => string,
-  statusBadgeStyles: Record<CollectionStatus, string>
+  status: string | undefined,
+  getStatusLabel: (status?: string) => string,
+  statusBadgeStyles: Record<string, string>
 ) => {
   if (!status) {
     return <span className="text-muted-foreground">-</span>;
   }
 
+  const normalized = status.toLowerCase();
+  const capitalized =
+    status.charAt(0).toUpperCase() + status.slice(1).toLowerCase();
   const badgeClasses =
-    statusBadgeStyles[status] || "border-gray-200 bg-gray-50";
+    statusBadgeStyles[status] ||
+    statusBadgeStyles[normalized] ||
+    statusBadgeStyles[status.toUpperCase()] ||
+    statusBadgeStyles[capitalized] ||
+    "border-gray-200 bg-gray-50 text-muted-foreground";
 
   return (
-    <Badge
-      variant="outline"
-      className={`${badgeClasses} font-normal`}
-    >
+    <Badge variant="outline" className={`${badgeClasses} font-normal`}>
       {getStatusLabel(status)}
     </Badge>
   );

--- a/packages/plugin-commerce-dashboard/src/modules/products/hooks/use-products-manage.tsx
+++ b/packages/plugin-commerce-dashboard/src/modules/products/hooks/use-products-manage.tsx
@@ -34,11 +34,16 @@ export interface ProductListItem {
 
 const ITEMS_PER_PAGE = 10;
 
-const STATUS_BADGE_STYLES: Record<ProductStatus, string> = {
-  draft: "border-yellow-700 bg-yellow-50",
-  active: "border-green-700 bg-green-50",
-  archived: "border-red-700 bg-red-50",
-};
+const STATUS_BADGE_STYLES = {
+  draft: "border-yellow-700 bg-yellow-50 text-yellow-800",
+  Draft: "border-yellow-700 bg-yellow-50 text-yellow-800",
+  active: "border-green-700 bg-green-50 text-green-800",
+  Active: "border-green-700 bg-green-50 text-green-800",
+  published: "border-green-700 bg-green-50 text-green-800",
+  Published: "border-green-700 bg-green-50 text-green-800",
+  archived: "border-red-700 bg-red-50 text-red-800",
+  Archived: "border-red-700 bg-red-50 text-red-800",
+} as const satisfies Record<string, string>;
 
 const isFilterValueEmpty = (value: unknown) => {
   if (value === null || value === undefined || value === "") return true;
@@ -426,11 +431,12 @@ export function useProductsManage() {
   );
 
   const getStatusLabel = useCallback(
-    (status?: ProductStatus) => {
+    (status?: string) => {
       if (!status) return "-";
-      const key = `products.status.${status}` as const;
-      const label = t(key);
-      return label === key ? status : label;
+      const normalized = status.toLowerCase();
+      const key = `products.status.${normalized}`;
+      const label = t(key, { defaultValue: status });
+      return label;
     },
     [t]
   );

--- a/packages/plugin-commerce-dashboard/src/modules/products/pages/products-manage.tsx
+++ b/packages/plugin-commerce-dashboard/src/modules/products/pages/products-manage.tsx
@@ -34,11 +34,7 @@ import {
   Trash,
   Trash2,
 } from "lucide-react";
-import {
-  type ProductListItem,
-  type ProductStatus,
-  useProductsManage,
-} from "../hooks/use-products-manage";
+import { type ProductListItem, useProductsManage } from "../hooks/use-products-manage";
 
 const renderTags = (tags: string[] | undefined) => {
   if (!tags || tags.length === 0) {
@@ -73,16 +69,23 @@ const renderTags = (tags: string[] | undefined) => {
 };
 
 const renderStatus = (
-  status: ProductStatus | undefined,
-  getStatusLabel: (status?: ProductStatus) => string,
-  statusBadgeStyles: Record<ProductStatus, string>
+  status: string | undefined,
+  getStatusLabel: (status?: string) => string,
+  statusBadgeStyles: Record<string, string>
 ) => {
   if (!status) {
     return <span className="text-muted-foreground">-</span>;
   }
 
+  const normalized = status.toLowerCase();
+  const capitalized =
+    status.charAt(0).toUpperCase() + status.slice(1).toLowerCase();
   const badgeClasses =
-    statusBadgeStyles[status] || "border-gray-200 bg-gray-50";
+    statusBadgeStyles[status] ||
+    statusBadgeStyles[normalized] ||
+    statusBadgeStyles[status.toUpperCase()] ||
+    statusBadgeStyles[capitalized] ||
+    "border-gray-200 bg-gray-50 text-muted-foreground";
 
   return (
     <Badge variant="outline" className={`${badgeClasses} font-normal`}>


### PR DESCRIPTION
## Summary
- update commerce product and collection tables to resolve status badges with consistent color styles even when API casing varies
- normalize status label lookups and add text color classes so badges match the broader dashboard styling
- add missing "published" translations for commerce product statuses

## Testing
- pnpm --filter @kitejs-cms/plugin-commerce-dashboard lint *(fails: existing unused variable warnings in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e6d150c4c083288f783d9068c30912