### PR TITLE
Add product variant management to commerce dashboard

### DIFF
--- a/packages/plugin-commerce-api/src/commerce/products/dto/partials/product-option.dto.ts
+++ b/packages/plugin-commerce-api/src/commerce/products/dto/partials/product-option.dto.ts
@@ -1,5 +1,5 @@
-import { ApiProperty } from "@nestjs/swagger";
-import { IsString, IsArray, IsNumber } from "class-validator";
+import { ApiProperty, ApiPropertyOptional } from "@nestjs/swagger";
+import { IsString, IsArray, IsNumber, IsOptional } from "class-validator";
 import { ProductOptionModel } from "../../models/partials/product-option.model";
 
 export class ProductOptionDto implements ProductOptionModel {
@@ -7,9 +7,10 @@ export class ProductOptionDto implements ProductOptionModel {
   @IsString()
   name: string;
 
-  @ApiProperty()
+  @ApiPropertyOptional()
+  @IsOptional()
   @IsString()
-  displayName: string;
+  displayName?: string;
 
   @ApiProperty({ type: [String] })
   @IsArray()

--- a/packages/plugin-commerce-api/src/commerce/products/dto/partials/product-variant.dto.ts
+++ b/packages/plugin-commerce-api/src/commerce/products/dto/partials/product-variant.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty, ApiPropertyOptional } from "@nestjs/swagger";
-import { Type } from "class-transformer";
+import { Exclude, Type } from "class-transformer";
 import {
   IsArray,
   IsBoolean,
@@ -71,6 +71,9 @@ export class ProductVariantDto implements ProductVariantModel {
   @IsOptional()
   @IsString()
   optionValue?: string;
+
+  @Exclude()
+  _id?: string;
 
   constructor(partial: ProductVariantModel) {
     Object.assign(this, partial);

--- a/packages/plugin-commerce-api/src/commerce/products/dto/partials/product-variant.dto.ts
+++ b/packages/plugin-commerce-api/src/commerce/products/dto/partials/product-variant.dto.ts
@@ -1,6 +1,7 @@
 import { ApiProperty, ApiPropertyOptional } from "@nestjs/swagger";
 import { Type } from "class-transformer";
 import {
+  IsArray,
   IsBoolean,
   IsNotEmpty,
   IsNumber,
@@ -49,6 +50,27 @@ export class ProductVariantDto implements ProductVariantModel {
   @IsOptional()
   @IsBoolean()
   allowBackorder?: boolean;
+
+  @ApiPropertyOptional({ type: () => [String] })
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  gallery?: string[];
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  downloadUrl?: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  optionName?: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  optionValue?: string;
 
   constructor(partial: ProductVariantModel) {
     Object.assign(this, partial);

--- a/packages/plugin-commerce-api/src/commerce/products/models/partials/product-option.model.ts
+++ b/packages/plugin-commerce-api/src/commerce/products/models/partials/product-option.model.ts
@@ -1,5 +1,6 @@
 export type ProductOptionModel = {
   name: string;
+  displayName?: string;
   values: string[];
   position: number;
 };

--- a/packages/plugin-commerce-api/src/commerce/products/models/partials/product-variant.model.ts
+++ b/packages/plugin-commerce-api/src/commerce/products/models/partials/product-variant.model.ts
@@ -8,4 +8,8 @@ export type ProductVariantModel = {
   prices?: ProductPriceModel[];
   inventoryQuantity?: number;
   allowBackorder?: boolean;
+  gallery?: string[];
+  optionName?: string;
+  optionValue?: string;
+  downloadUrl?: string;
 };

--- a/packages/plugin-commerce-api/src/commerce/products/products.service.ts
+++ b/packages/plugin-commerce-api/src/commerce/products/products.service.ts
@@ -28,6 +28,26 @@ export class ProductsService {
   private readonly logger = new Logger(ProductsService.name);
   private readonly slugNamespace = COMMERCE_PRODUCT_SLUG_NAMESPACE;
 
+  private formatUserIdentifier(
+    user?: Types.ObjectId | User | null
+  ): string | null {
+    if (!user) return null;
+
+    if ((user as User).firstName && (user as User).lastName) {
+      return `${(user as User).firstName} ${(user as User).lastName}`;
+    }
+
+    if (typeof (user as Types.ObjectId).toHexString === "function") {
+      return (user as Types.ObjectId).toHexString();
+    }
+
+    if (typeof (user as any).toString === "function") {
+      return (user as any).toString();
+    }
+
+    return null;
+  }
+
   constructor(
     @InjectModel(Product.name)
     private readonly productModel: Model<ProductDocument>,
@@ -330,8 +350,8 @@ export class ProductsService {
         thumbnail,
         translations: translationsWithSlug,
         collections: product.collections.map((c) => c.toString()),
-        createdBy: product.createdBy ? product.createdBy.toString() : null,
-        updatedBy: product.updatedBy ? product.updatedBy.toString() : null,
+        createdBy: this.formatUserIdentifier(product.createdBy),
+        updatedBy: this.formatUserIdentifier(product.updatedBy),
       };
     } catch (error) {
       this.logger.error(error);

--- a/packages/plugin-commerce-api/src/commerce/products/schemas/product-option.schema.ts
+++ b/packages/plugin-commerce-api/src/commerce/products/schemas/product-option.schema.ts
@@ -5,6 +5,9 @@ class ProductOption {
   @Prop({ type: String, required: true })
   name!: string;
 
+  @Prop({ type: String, required: false })
+  displayName?: string;
+
   @Prop({ type: [String], default: [] })
   values!: string[];
 

--- a/packages/plugin-commerce-dashboard/package.json
+++ b/packages/plugin-commerce-dashboard/package.json
@@ -36,6 +36,7 @@
   },
   "peerDependencies": {
     "@kitejs-cms/dashboard-core": "workspace:*",
+    "i18next": "^25.6.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-i18next": "^16.2.0",
@@ -53,6 +54,7 @@
     "@types/react": "19.0.8",
     "@types/react-dom": "19.0.3",
     "eslint": "^9.20.0",
+    "i18next": "^25.6.0",
     "tailwindcss-animate": "^1.0.7",
     "typescript": "5.7.3"
   }

--- a/packages/plugin-commerce-dashboard/src/locales/en/products/details.json
+++ b/packages/plugin-commerce-dashboard/src/locales/en/products/details.json
@@ -82,6 +82,13 @@
       "price": "Price",
       "compareAt": "Compare at price",
       "currency": "Currency",
+      "optionHeader": "Option assignment",
+      "optionDescription": "Choose which option and value this variant represents.",
+      "optionName": "Option group",
+      "optionValue": "Option value",
+      "optionNamePlaceholder": "Select an option",
+      "optionValuePlaceholder": "Select a value",
+      "optionValueEmpty": "Add values to this option to make them available here.",
       "backorder": "Allow backorders",
       "backorderDescription": "Let customers purchase this variant even when it's out of stock.",
       "media": "Gallery images",
@@ -95,6 +102,8 @@
     "preview": {
       "untitled": "Untitled variant",
       "missingSku": "SKU not set",
+      "missingOption": "Option not set",
+      "missingOptionValue": "Value not set",
       "inventoryCount": "{{count}} in stock",
       "inventoryFallback": "No inventory configured"
     },
@@ -103,6 +112,32 @@
       "description": "Choose which gallery images should be associated with this variant.",
       "confirm": "Save selection"
     }
+  },
+  "options": {
+    "title": "Options",
+    "description": "Define shared option groups and values that variants can reference.",
+    "add": "Add option",
+    "remove": "Remove option",
+    "empty": "No options configured yet.",
+    "untitled": "Untitled option",
+    "defaultName": "Option {{index}}",
+    "optionSummary_one": "{{count}} value configured",
+    "optionSummary_other": "{{count}} values configured",
+    "fields": {
+      "displayName": "Display name",
+      "displayNamePlaceholder": "e.g. Color",
+      "displayNameHint": "Shown to customers in the dashboard and storefront.",
+      "handle": "Handle",
+      "handlePlaceholder": "e.g. color",
+      "handleHint": "Lowercase handle used in the API payload.",
+      "values": "Values",
+      "valuesCount_one": "{{count}} value",
+      "valuesCount_other": "{{count}} values",
+      "valuesEmpty": "No values configured yet.",
+      "newValuePlaceholder": "Add a value",
+      "addValue": "Add value"
+    },
+    "removeValue": "Remove value"
   },
   "notifications": {
     "saving": "Saving product...",

--- a/packages/plugin-commerce-dashboard/src/locales/en/products/details.json
+++ b/packages/plugin-commerce-dashboard/src/locales/en/products/details.json
@@ -83,7 +83,16 @@
       "compareAt": "Compare at price",
       "currency": "Currency",
       "backorder": "Allow backorders",
-      "backorderDescription": "Let customers purchase this variant even when it's out of stock."
+      "backorderDescription": "Let customers purchase this variant even when it's out of stock.",
+      "media": "Gallery images",
+      "mediaDescription": "Select images from the product gallery to represent this variant.",
+      "mediaEmpty": "Add media to the product gallery to link images here."
+    },
+    "preview": {
+      "untitled": "Untitled variant",
+      "missingSku": "SKU not set",
+      "inventoryCount": "{{count}} in stock",
+      "inventoryFallback": "No inventory configured"
     }
   },
   "notifications": {

--- a/packages/plugin-commerce-dashboard/src/locales/en/products/details.json
+++ b/packages/plugin-commerce-dashboard/src/locales/en/products/details.json
@@ -81,7 +81,9 @@
       "inventory": "Inventory quantity",
       "price": "Price",
       "compareAt": "Compare at price",
-      "currency": "Currency"
+      "currency": "Currency",
+      "backorder": "Allow backorders",
+      "backorderDescription": "Let customers purchase this variant even when it's out of stock."
     }
   },
   "notifications": {

--- a/packages/plugin-commerce-dashboard/src/locales/en/products/details.json
+++ b/packages/plugin-commerce-dashboard/src/locales/en/products/details.json
@@ -86,13 +86,22 @@
       "backorderDescription": "Let customers purchase this variant even when it's out of stock.",
       "media": "Gallery images",
       "mediaDescription": "Select images from the product gallery to represent this variant.",
-      "mediaEmpty": "Add media to the product gallery to link images here."
+      "mediaEmpty": "Add media to the product gallery to link images here.",
+      "mediaSelect": "Choose images",
+      "mediaPreviewEmpty": "No images selected for this variant yet.",
+      "mediaSelected_one": "{{count}} image selected",
+      "mediaSelected_other": "{{count}} images selected"
     },
     "preview": {
       "untitled": "Untitled variant",
       "missingSku": "SKU not set",
       "inventoryCount": "{{count}} in stock",
       "inventoryFallback": "No inventory configured"
+    },
+    "galleryDialog": {
+      "title": "Select variant media",
+      "description": "Choose which gallery images should be associated with this variant.",
+      "confirm": "Save selection"
     }
   },
   "notifications": {

--- a/packages/plugin-commerce-dashboard/src/locales/en/products/errors.json
+++ b/packages/plugin-commerce-dashboard/src/locales/en/products/errors.json
@@ -6,5 +6,8 @@
   "unsavedChanges": "You have unsaved product changes.",
   "discardChanges": "Discard unsaved changes?",
   "variantTitleRequired": "Variant name is required.",
-  "variantSkuRequired": "Variant SKU is required."
+  "variantSkuRequired": "Variant SKU is required.",
+  "variantOptionRequired": "Select an option for each variant.",
+  "variantOptionValueRequired": "Select a value for this option.",
+  "variantOptionValueInvalid": "Select a valid value for this option."
 }

--- a/packages/plugin-commerce-dashboard/src/locales/en/products/errors.json
+++ b/packages/plugin-commerce-dashboard/src/locales/en/products/errors.json
@@ -4,5 +4,7 @@
   "thumbnailRequired": "Select a featured image for this product.",
   "saveFailed": "Unable to save product. Please try again.",
   "unsavedChanges": "You have unsaved product changes.",
-  "discardChanges": "Discard unsaved changes?"
+  "discardChanges": "Discard unsaved changes?",
+  "variantTitleRequired": "Variant name is required.",
+  "variantSkuRequired": "Variant SKU is required."
 }

--- a/packages/plugin-commerce-dashboard/src/locales/it/products/details.json
+++ b/packages/plugin-commerce-dashboard/src/locales/it/products/details.json
@@ -81,7 +81,9 @@
       "inventory": "Quantità a magazzino",
       "price": "Prezzo",
       "compareAt": "Prezzo di confronto",
-      "currency": "Valuta"
+      "currency": "Valuta",
+      "backorder": "Consenti preordini",
+      "backorderDescription": "Permetti ai clienti di acquistare la variante anche quando non è disponibile in magazzino."
     }
   },
   "notifications": {

--- a/packages/plugin-commerce-dashboard/src/locales/it/products/details.json
+++ b/packages/plugin-commerce-dashboard/src/locales/it/products/details.json
@@ -83,7 +83,16 @@
       "compareAt": "Prezzo di confronto",
       "currency": "Valuta",
       "backorder": "Consenti preordini",
-      "backorderDescription": "Permetti ai clienti di acquistare la variante anche quando non è disponibile in magazzino."
+      "backorderDescription": "Permetti ai clienti di acquistare la variante anche quando non è disponibile in magazzino.",
+      "media": "Immagini galleria",
+      "mediaDescription": "Seleziona le immagini dalla galleria del prodotto da associare a questa variante.",
+      "mediaEmpty": "Aggiungi media alla galleria del prodotto per collegarli qui."
+    },
+    "preview": {
+      "untitled": "Variante senza nome",
+      "missingSku": "SKU non impostato",
+      "inventoryCount": "{{count}} in magazzino",
+      "inventoryFallback": "Quantità non impostata"
     }
   },
   "notifications": {

--- a/packages/plugin-commerce-dashboard/src/locales/it/products/details.json
+++ b/packages/plugin-commerce-dashboard/src/locales/it/products/details.json
@@ -86,13 +86,22 @@
       "backorderDescription": "Permetti ai clienti di acquistare la variante anche quando non è disponibile in magazzino.",
       "media": "Immagini galleria",
       "mediaDescription": "Seleziona le immagini dalla galleria del prodotto da associare a questa variante.",
-      "mediaEmpty": "Aggiungi media alla galleria del prodotto per collegarli qui."
+      "mediaEmpty": "Aggiungi media alla galleria del prodotto per collegarli qui.",
+      "mediaSelect": "Scegli immagini",
+      "mediaPreviewEmpty": "Nessuna immagine selezionata per questa variante.",
+      "mediaSelected_one": "{{count}} immagine selezionata",
+      "mediaSelected_other": "{{count}} immagini selezionate"
     },
     "preview": {
       "untitled": "Variante senza nome",
       "missingSku": "SKU non impostato",
       "inventoryCount": "{{count}} in magazzino",
       "inventoryFallback": "Quantità non impostata"
+    },
+    "galleryDialog": {
+      "title": "Seleziona media della variante",
+      "description": "Scegli quali immagini della galleria associare a questa variante.",
+      "confirm": "Salva selezione"
     }
   },
   "notifications": {

--- a/packages/plugin-commerce-dashboard/src/locales/it/products/details.json
+++ b/packages/plugin-commerce-dashboard/src/locales/it/products/details.json
@@ -82,6 +82,13 @@
       "price": "Prezzo",
       "compareAt": "Prezzo di confronto",
       "currency": "Valuta",
+      "optionHeader": "Assegnazione opzione",
+      "optionDescription": "Scegli quale opzione e valore rappresenta questa variante.",
+      "optionName": "Gruppo opzione",
+      "optionValue": "Valore opzione",
+      "optionNamePlaceholder": "Seleziona un'opzione",
+      "optionValuePlaceholder": "Seleziona un valore",
+      "optionValueEmpty": "Aggiungi valori a questa opzione per renderli disponibili qui.",
       "backorder": "Consenti preordini",
       "backorderDescription": "Permetti ai clienti di acquistare la variante anche quando non è disponibile in magazzino.",
       "media": "Immagini galleria",
@@ -95,6 +102,8 @@
     "preview": {
       "untitled": "Variante senza nome",
       "missingSku": "SKU non impostato",
+      "missingOption": "Opzione non impostata",
+      "missingOptionValue": "Valore non impostato",
       "inventoryCount": "{{count}} in magazzino",
       "inventoryFallback": "Quantità non impostata"
     },
@@ -103,6 +112,32 @@
       "description": "Scegli quali immagini della galleria associare a questa variante.",
       "confirm": "Salva selezione"
     }
+  },
+  "options": {
+    "title": "Opzioni",
+    "description": "Definisci gruppi di opzioni condivisi e i relativi valori da associare alle varianti.",
+    "add": "Aggiungi opzione",
+    "remove": "Rimuovi opzione",
+    "empty": "Nessuna opzione configurata.",
+    "untitled": "Opzione senza titolo",
+    "defaultName": "Opzione {{index}}",
+    "optionSummary_one": "{{count}} valore configurato",
+    "optionSummary_other": "{{count}} valori configurati",
+    "fields": {
+      "displayName": "Nome visualizzato",
+      "displayNamePlaceholder": "es. Colore",
+      "displayNameHint": "Visibile ai clienti nel pannello e nello store.",
+      "handle": "Handle",
+      "handlePlaceholder": "es. colore",
+      "handleHint": "Identificativo minuscolo utilizzato nella richiesta API.",
+      "values": "Valori",
+      "valuesCount_one": "{{count}} valore",
+      "valuesCount_other": "{{count}} valori",
+      "valuesEmpty": "Nessun valore configurato.",
+      "newValuePlaceholder": "Aggiungi un valore",
+      "addValue": "Aggiungi valore"
+    },
+    "removeValue": "Rimuovi valore"
   },
   "notifications": {
     "saving": "Salvataggio prodotto...",

--- a/packages/plugin-commerce-dashboard/src/locales/it/products/errors.json
+++ b/packages/plugin-commerce-dashboard/src/locales/it/products/errors.json
@@ -6,5 +6,8 @@
   "unsavedChanges": "Ci sono modifiche non salvate al prodotto.",
   "discardChanges": "Vuoi scartare le modifiche non salvate?",
   "variantTitleRequired": "Il nome della variante è obbligatorio.",
-  "variantSkuRequired": "Lo SKU della variante è obbligatorio."
+  "variantSkuRequired": "Lo SKU della variante è obbligatorio.",
+  "variantOptionRequired": "Seleziona un'opzione per ogni variante.",
+  "variantOptionValueRequired": "Seleziona un valore per questa opzione.",
+  "variantOptionValueInvalid": "Seleziona un valore valido per questa opzione."
 }

--- a/packages/plugin-commerce-dashboard/src/locales/it/products/errors.json
+++ b/packages/plugin-commerce-dashboard/src/locales/it/products/errors.json
@@ -4,5 +4,7 @@
   "thumbnailRequired": "Seleziona un'immagine principale per questo prodotto.",
   "saveFailed": "Impossibile salvare il prodotto. Riprova.",
   "unsavedChanges": "Ci sono modifiche non salvate al prodotto.",
-  "discardChanges": "Vuoi scartare le modifiche non salvate?"
+  "discardChanges": "Vuoi scartare le modifiche non salvate?",
+  "variantTitleRequired": "Il nome della variante è obbligatorio.",
+  "variantSkuRequired": "Lo SKU della variante è obbligatorio."
 }

--- a/packages/plugin-commerce-dashboard/src/modules/products/components/options-section.tsx
+++ b/packages/plugin-commerce-dashboard/src/modules/products/components/options-section.tsx
@@ -67,7 +67,7 @@ export function OptionsSection({
         {options.length > 0 && (
           <div className="space-y-4">
             {options.map((option, index) => {
-              const optionKey = option.name || `option-${index}`;
+              const optionKey = String(option.position ?? index);
               const valueInput = valueInputs[optionKey] ?? "";
               const valueCount = option.values?.length ?? 0;
 

--- a/packages/plugin-commerce-dashboard/src/modules/products/components/options-section.tsx
+++ b/packages/plugin-commerce-dashboard/src/modules/products/components/options-section.tsx
@@ -1,0 +1,219 @@
+import { useState } from "react";
+import { Plus, Trash2, X } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import {
+  Button,
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  Input,
+  Label,
+  Separator,
+} from "@kitejs-cms/dashboard-core";
+import type { ProductOptionModel } from "@kitejs-cms/plugin-commerce-api";
+
+interface OptionsSectionProps {
+  options: ProductOptionModel[];
+  onAddOption: () => void;
+  onRemoveOption: (index: number) => void;
+  onOptionChange: (index: number, field: "name" | "displayName", value: string) => void;
+  onOptionValueAdd: (index: number, value: string) => void;
+  onOptionValueRemove: (index: number, value: string) => void;
+}
+
+export function OptionsSection({
+  options,
+  onAddOption,
+  onRemoveOption,
+  onOptionChange,
+  onOptionValueAdd,
+  onOptionValueRemove,
+}: OptionsSectionProps) {
+  const { t } = useTranslation("commerce");
+  const [valueInputs, setValueInputs] = useState<Record<string, string>>({});
+
+  const emptyState = (
+    <div className="rounded-md border border-dashed border-muted-foreground/40 bg-muted/40 p-6 text-center text-sm text-muted-foreground">
+      {t("products.details.options.empty")}
+    </div>
+  );
+
+  return (
+    <Card className="w-full gap-0 py-0 shadow-neutral-50">
+      <CardHeader className="rounded-t-xl bg-secondary py-6 text-primary">
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <CardTitle>{t("products.details.options.title")}</CardTitle>
+            <p className="text-sm text-primary/70">
+              {t("products.details.options.description")}
+            </p>
+          </div>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="flex items-center gap-2"
+            onClick={onAddOption}
+          >
+            <Plus className="h-4 w-4" />
+            {t("products.details.options.add")}
+          </Button>
+        </div>
+      </CardHeader>
+      <Separator />
+      <CardContent className="space-y-4 p-4 md:p-6">
+        {options.length === 0 && emptyState}
+        {options.length > 0 && (
+          <div className="space-y-4">
+            {options.map((option, index) => {
+              const optionKey = option.name || `option-${index}`;
+              const valueInput = valueInputs[optionKey] ?? "";
+              const valueCount = option.values?.length ?? 0;
+
+              const handleRemove = () => {
+                onRemoveOption(index);
+                setValueInputs((prev) => {
+                  const next = { ...prev };
+                  delete next[optionKey];
+                  return next;
+                });
+              };
+
+              const handleValueAdd = () => {
+                const trimmed = valueInput.trim();
+                if (!trimmed) return;
+                onOptionValueAdd(index, trimmed);
+                setValueInputs((prev) => ({ ...prev, [optionKey]: "" }));
+              };
+
+              return (
+                <div
+                  key={optionKey}
+                  className="space-y-4 rounded-lg border border-border bg-background p-4 shadow-sm"
+                >
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="space-y-1">
+                      <p className="text-sm font-medium">
+                        {option.displayName ?? option.name ?? t("products.details.options.untitled")}
+                      </p>
+                      <p className="text-xs text-muted-foreground">
+                        {t("products.details.options.optionSummary", { count: valueCount })}
+                      </p>
+                    </div>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon"
+                      className="text-destructive hover:text-destructive"
+                      onClick={handleRemove}
+                      aria-label={t("products.details.options.remove")}
+                    >
+                      <Trash2 className="h-4 w-4" />
+                    </Button>
+                  </div>
+
+                  <div className="grid gap-4 md:grid-cols-2">
+                    <div className="space-y-2">
+                      <Label>{t("products.details.options.fields.displayName")}</Label>
+                      <Input
+                        value={option.displayName ?? ""}
+                        onChange={(event) =>
+                          onOptionChange(index, "displayName", event.target.value)
+                        }
+                        placeholder={t(
+                          "products.details.options.fields.displayNamePlaceholder"
+                        )}
+                      />
+                      <p className="text-xs text-muted-foreground">
+                        {t("products.details.options.fields.displayNameHint")}
+                      </p>
+                    </div>
+                    <div className="space-y-2">
+                      <Label>{t("products.details.options.fields.handle")}</Label>
+                      <Input
+                        value={option.name ?? ""}
+                        onChange={(event) =>
+                          onOptionChange(index, "name", event.target.value)
+                        }
+                        placeholder={t(
+                          "products.details.options.fields.handlePlaceholder"
+                        )}
+                      />
+                      <p className="text-xs text-muted-foreground">
+                        {t("products.details.options.fields.handleHint")}
+                      </p>
+                    </div>
+                  </div>
+
+                  <div className="space-y-3">
+                    <div className="flex items-center justify-between">
+                      <Label>{t("products.details.options.fields.values")}</Label>
+                      {valueCount > 0 && (
+                        <span className="text-xs text-muted-foreground">
+                          {t("products.details.options.fields.valuesCount", {
+                            count: valueCount,
+                          })}
+                        </span>
+                      )}
+                    </div>
+                    {valueCount > 0 ? (
+                      <div className="flex flex-wrap gap-2">
+                        {option.values?.map((value) => (
+                          <div
+                            key={value}
+                            className="flex items-center gap-1 rounded-full border border-muted-foreground/40 bg-muted px-3 py-1 text-xs font-medium text-muted-foreground"
+                          >
+                            <span>{value}</span>
+                            <button
+                              type="button"
+                              className="text-muted-foreground transition hover:text-destructive"
+                              onClick={() => onOptionValueRemove(index, value)}
+                              aria-label={t("products.details.options.removeValue")}
+                            >
+                              <X className="h-3 w-3" />
+                            </button>
+                          </div>
+                        ))}
+                      </div>
+                    ) : (
+                      <p className="text-xs text-muted-foreground">
+                        {t("products.details.options.fields.valuesEmpty")}
+                      </p>
+                    )}
+                    <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+                      <Input
+                        value={valueInput}
+                        onChange={(event) =>
+                          setValueInputs((prev) => ({
+                            ...prev,
+                            [optionKey]: event.target.value,
+                          }))
+                        }
+                        placeholder={t(
+                          "products.details.options.fields.newValuePlaceholder"
+                        )}
+                        className="sm:w-48"
+                      />
+                      <Button
+                        type="button"
+                        size="sm"
+                        variant="outline"
+                        className="flex items-center gap-2"
+                        onClick={handleValueAdd}
+                        disabled={!valueInput.trim()}
+                      >
+                        <Plus className="h-4 w-4" />
+                        {t("products.details.options.fields.addValue")}
+                      </Button>
+                    </div>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/packages/plugin-commerce-dashboard/src/modules/products/components/variants-section.tsx
+++ b/packages/plugin-commerce-dashboard/src/modules/products/components/variants-section.tsx
@@ -20,6 +20,14 @@ import {
   Separator,
   Switch,
 } from "@kitejs-cms/dashboard-core";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@kitejs-cms/dashboard-core/components/ui/dialog";
 import type {
   ProductPriceModel,
   ProductVariantModel,
@@ -111,6 +119,13 @@ export function VariantsSection({
 }: VariantsSectionProps) {
   const { t } = useTranslation("commerce");
   const [expanded, setExpanded] = useState<number | null>(null);
+  const [galleryDialog, setGalleryDialog] = useState<
+    | {
+        index: number;
+        selection: string[];
+      }
+    | null
+  >(null);
 
   const galleryLookup = useMemo(() => {
     const map = new Map<string, VariantGalleryOption>();
@@ -191,17 +206,6 @@ export function VariantsSection({
                   : t("products.details.variants.preview.inventoryFallback");
               const isExpanded = expanded === index;
               const errors = variantErrors?.[index];
-
-              const toggleGallerySelection = (assetId: string) => {
-                if (selectedGallery.includes(assetId)) {
-                  onVariantGalleryChange(
-                    index,
-                    selectedGallery.filter((entry) => entry !== assetId)
-                  );
-                } else {
-                  onVariantGalleryChange(index, [...selectedGallery, assetId]);
-                }
-              };
 
               return (
                 <div
@@ -413,45 +417,72 @@ export function VariantsSection({
                             {t("products.details.variants.fields.mediaDescription")}
                           </p>
                         </div>
-                        {productGallery.length > 0 ? (
-                          <div className="flex flex-wrap gap-3">
-                            {productGallery.map((asset) => {
-                              const isSelected = selectedGallery.includes(asset.id);
-                              return (
-                                <button
-                                  type="button"
-                                  key={asset.id}
-                                  className={`relative flex h-16 w-16 items-center justify-center overflow-hidden rounded-md border transition ${
-                                    isSelected
-                                      ? "border-primary ring-2 ring-primary"
-                                      : "border-muted bg-muted"
-                                  }`}
-                                  onClick={() => toggleGallerySelection(asset.id)}
-                                  aria-pressed={isSelected}
-                                >
-                                  {asset.url ? (
-                                    <img
-                                      src={asset.url}
-                                      alt={asset.label}
-                                      className="h-full w-full object-cover"
-                                    />
-                                  ) : (
-                                    <ImageIcon className="h-5 w-5 text-muted-foreground" />
-                                  )}
-                                  {isSelected && (
-                                    <span className="absolute right-1 top-1 rounded-full bg-primary p-1 text-primary-foreground">
-                                      <Check className="h-3 w-3" />
-                                    </span>
-                                  )}
-                                </button>
-                              );
-                            })}
-                          </div>
-                        ) : (
-                          <p className="text-xs text-muted-foreground">
-                            {t("products.details.variants.fields.mediaEmpty")}
-                          </p>
-                        )}
+                        <div className="space-y-2">
+                          {selectedGallery.length > 0 ? (
+                            <div className="flex flex-wrap gap-2">
+                              {selectedGallery.map((assetId) => {
+                                const asset = galleryLookup.get(assetId);
+                                return (
+                                  <div
+                                    key={assetId}
+                                    className="flex h-12 w-12 items-center justify-center overflow-hidden rounded-md border border-muted bg-muted"
+                                  >
+                                    {asset?.url ? (
+                                      <img
+                                        src={asset.url}
+                                        alt={asset.label}
+                                        className="h-full w-full object-cover"
+                                      />
+                                    ) : (
+                                      <span className="text-[10px] font-medium text-muted-foreground">
+                                        {asset?.label ?? assetId}
+                                      </span>
+                                    )}
+                                  </div>
+                                );
+                              })}
+                            </div>
+                          ) : (
+                            <p className="text-xs text-muted-foreground">
+                              {t(
+                                "products.details.variants.fields.mediaPreviewEmpty"
+                              )}
+                            </p>
+                          )}
+                          {selectedGallery.length > 0 && (
+                            <Badge variant="outline" className="w-fit text-xs font-normal">
+                              {t(
+                                "products.details.variants.fields.mediaSelected",
+                                { count: selectedGallery.length }
+                              )}
+                            </Badge>
+                          )}
+                        </div>
+                        <div className="flex flex-wrap items-center gap-2">
+                          <Button
+                            type="button"
+                            size="sm"
+                            variant="outline"
+                            className="flex items-center gap-2"
+                            disabled={productGallery.length === 0}
+                            onClick={(event) => {
+                              event.stopPropagation();
+                              if (productGallery.length === 0) return;
+                              setGalleryDialog({
+                                index,
+                                selection: [...selectedGallery],
+                              });
+                            }}
+                          >
+                            <ImageIcon className="h-4 w-4" />
+                            {t("products.details.variants.fields.mediaSelect")}
+                          </Button>
+                          {productGallery.length === 0 && (
+                            <p className="text-xs text-muted-foreground">
+                              {t("products.details.variants.fields.mediaEmpty")}
+                            </p>
+                          )}
+                        </div>
                         {errors?.gallery && (
                           <p className="text-xs text-destructive">{errors.gallery}</p>
                         )}
@@ -486,6 +517,92 @@ export function VariantsSection({
           </div>
         )}
       </CardContent>
+      <Dialog
+        open={Boolean(galleryDialog)}
+        onClose={() => setGalleryDialog(null)}
+      >
+        <DialogContent className="max-w-3xl space-y-6">
+          <DialogHeader>
+            <DialogTitle>
+              {t("products.details.variants.galleryDialog.title")}
+            </DialogTitle>
+            <DialogDescription>
+              {t("products.details.variants.galleryDialog.description")}
+            </DialogDescription>
+          </DialogHeader>
+          {productGallery.length > 0 ? (
+            <div className="grid gap-4 sm:grid-cols-2 md:grid-cols-3">
+              {productGallery.map((asset) => {
+                const isSelected = galleryDialog?.selection.includes(asset.id);
+                return (
+                  <button
+                    key={asset.id}
+                    type="button"
+                    className={`relative flex h-32 w-full items-center justify-center overflow-hidden rounded-lg border transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 ${
+                      isSelected
+                        ? "border-primary ring-2 ring-primary"
+                        : "border-muted bg-muted"
+                    }`}
+                    onClick={() =>
+                      setGalleryDialog((prev) => {
+                        if (!prev) return prev;
+                        const exists = prev.selection.includes(asset.id);
+                        const nextSelection = exists
+                          ? prev.selection.filter((entry) => entry !== asset.id)
+                          : [...prev.selection, asset.id];
+                        return { ...prev, selection: nextSelection };
+                      })
+                    }
+                    aria-pressed={isSelected}
+                  >
+                    {asset.url ? (
+                      <img
+                        src={asset.url}
+                        alt={asset.label}
+                        className="h-full w-full object-cover"
+                      />
+                    ) : (
+                      <div className="flex h-full w-full flex-col items-center justify-center gap-2 p-4 text-center text-sm text-muted-foreground">
+                        <ImageIcon className="h-6 w-6" />
+                        <span className="line-clamp-2">{asset.label}</span>
+                      </div>
+                    )}
+                    {isSelected && (
+                      <span className="absolute right-2 top-2 rounded-full bg-primary p-1 text-primary-foreground">
+                        <Check className="h-4 w-4" />
+                      </span>
+                    )}
+                  </button>
+                );
+              })}
+            </div>
+          ) : (
+            <p className="text-sm text-muted-foreground">
+              {t("products.details.variants.fields.mediaEmpty")}
+            </p>
+          )}
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => setGalleryDialog(null)}
+            >
+              {t("products.buttons.cancel")}
+            </Button>
+            <Button
+              type="button"
+              onClick={() => {
+                if (!galleryDialog) return;
+                onVariantGalleryChange(galleryDialog.index, galleryDialog.selection);
+                setGalleryDialog(null);
+              }}
+              disabled={!galleryDialog}
+            >
+              {t("products.details.variants.galleryDialog.confirm")}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </Card>
   );
 }

--- a/packages/plugin-commerce-dashboard/src/modules/products/components/variants-section.tsx
+++ b/packages/plugin-commerce-dashboard/src/modules/products/components/variants-section.tsx
@@ -17,6 +17,11 @@ import {
   CardTitle,
   Input,
   Label,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
   Separator,
   Switch,
 } from "@kitejs-cms/dashboard-core";
@@ -31,6 +36,7 @@ import {
 import type {
   ProductPriceModel,
   ProductVariantModel,
+  ProductOptionModel,
 } from "@kitejs-cms/plugin-commerce-api";
 
 export type VariantState = ProductVariantModel & {
@@ -38,7 +44,15 @@ export type VariantState = ProductVariantModel & {
 };
 
 export type VariantFieldErrors = Partial<
-  Record<"title" | "sku" | "inventoryQuantity" | "gallery", string>
+  Record<
+    | "title"
+    | "sku"
+    | "inventoryQuantity"
+    | "gallery"
+    | "optionName"
+    | "optionValue",
+    string
+  >
 >;
 
 export interface VariantGalleryOption {
@@ -51,6 +65,7 @@ interface VariantsSectionProps {
   variants: VariantState[];
   defaultCurrency: string;
   productGallery: VariantGalleryOption[];
+  productOptions: ProductOptionModel[];
   variantErrors?: VariantFieldErrors[];
   onAddVariant: () => void;
   onRemoveVariant: (index: number) => void;
@@ -61,7 +76,9 @@ interface VariantsSectionProps {
       | "sku"
       | "barcode"
       | "inventoryQuantity"
-      | "allowBackorder",
+      | "allowBackorder"
+      | "optionName"
+      | "optionValue",
     value: string | number | boolean | undefined
   ) => void;
   onVariantPriceChange: (
@@ -110,6 +127,7 @@ export function VariantsSection({
   variants,
   defaultCurrency,
   productGallery,
+  productOptions,
   variantErrors,
   onAddVariant,
   onRemoveVariant,
@@ -134,6 +152,16 @@ export function VariantsSection({
     });
     return map;
   }, [productGallery]);
+
+  const optionLookup = useMemo(() => {
+    const map = new Map<string, ProductOptionModel>();
+    productOptions.forEach((option) => {
+      if (option?.name) {
+        map.set(option.name, option);
+      }
+    });
+    return map;
+  }, [productOptions]);
 
   const emptyState = (
     <div className="rounded-md border border-dashed border-muted-foreground/40 bg-muted/40 p-6 text-center text-sm text-muted-foreground">
@@ -204,6 +232,46 @@ export function VariantsSection({
                       count: variant.inventoryQuantity,
                     })
                   : t("products.details.variants.preview.inventoryFallback");
+              const option =
+                variant.optionName && optionLookup.has(variant.optionName)
+                  ? optionLookup.get(variant.optionName)
+                  : undefined;
+              const availableValues = option?.values ?? [];
+              const optionPreview = (() => {
+                if (option) {
+                  const value = variant.optionValue?.trim();
+                  if (value) {
+                    return `${option.displayName ?? option.name}: ${value}`;
+                  }
+                  return t(
+                    "products.details.variants.preview.missingOptionValue",
+                    "Missing option value"
+                  );
+                }
+                if (variant.optionName?.trim() || variant.optionValue?.trim()) {
+                  const name = variant.optionName?.trim();
+                  const value = variant.optionValue?.trim();
+                  if (name && value) {
+                    return `${name}: ${value}`;
+                  }
+                  if (name) {
+                    return `${name}: ${t(
+                      "products.details.variants.preview.missingOptionValue",
+                      "Missing option value"
+                    )}`;
+                  }
+                  if (value) {
+                    return `${t(
+                      "products.details.variants.preview.missingOption",
+                      "Missing option"
+                    )}: ${value}`;
+                  }
+                }
+                return t(
+                  "products.details.variants.preview.missingOption",
+                  "Missing option"
+                );
+              })();
               const isExpanded = expanded === index;
               const errors = variantErrors?.[index];
 
@@ -240,6 +308,9 @@ export function VariantsSection({
                         <span className="text-xs text-muted-foreground">
                           {variant.sku?.trim() ||
                             t("products.details.variants.preview.missingSku")}
+                        </span>
+                        <span className="text-xs text-muted-foreground">
+                          {optionPreview}
                         </span>
                       </div>
                     </div>
@@ -408,6 +479,127 @@ export function VariantsSection({
                             }
                           />
                         </div>
+                      </div>
+
+                      <div className="space-y-3">
+                        <div>
+                          <Label>{t("products.details.variants.fields.optionHeader")}</Label>
+                          <p className="text-xs text-muted-foreground">
+                            {t("products.details.variants.fields.optionDescription")}
+                          </p>
+                        </div>
+                        {productOptions.length > 0 ? (
+                          <div className="grid gap-4 md:grid-cols-2">
+                            <div className="space-y-2">
+                              <Label className="text-xs text-muted-foreground">
+                                {t("products.details.variants.fields.optionName")}
+                              </Label>
+                              <Select
+                                value={variant.optionName ?? undefined}
+                                onValueChange={(value) =>
+                                  onVariantChange(index, "optionName", value)
+                                }
+                              >
+                                <SelectTrigger>
+                                  <SelectValue
+                                    placeholder={t(
+                                      "products.details.variants.fields.optionNamePlaceholder"
+                                    )}
+                                  />
+                                </SelectTrigger>
+                                <SelectContent>
+                                  {productOptions.map((optionItem) => (
+                                    <SelectItem
+                                      key={optionItem.name}
+                                      value={optionItem.name}
+                                    >
+                                      {optionItem.displayName ?? optionItem.name}
+                                    </SelectItem>
+                                  ))}
+                                </SelectContent>
+                              </Select>
+                              {errors?.optionName && (
+                                <p className="text-xs text-destructive">
+                                  {errors.optionName}
+                                </p>
+                              )}
+                            </div>
+                            <div className="space-y-2">
+                              <Label className="text-xs text-muted-foreground">
+                                {t("products.details.variants.fields.optionValue")}
+                              </Label>
+                              <Select
+                                value={variant.optionValue ?? undefined}
+                                onValueChange={(value) =>
+                                  onVariantChange(index, "optionValue", value)
+                                }
+                                disabled={availableValues.length === 0}
+                              >
+                                <SelectTrigger>
+                                  <SelectValue
+                                    placeholder={t(
+                                      "products.details.variants.fields.optionValuePlaceholder"
+                                    )}
+                                  />
+                                </SelectTrigger>
+                                <SelectContent>
+                                  {availableValues.map((value) => (
+                                    <SelectItem key={value} value={value}>
+                                      {value}
+                                    </SelectItem>
+                                  ))}
+                                </SelectContent>
+                              </Select>
+                              {availableValues.length === 0 && (
+                                <p className="text-xs text-muted-foreground">
+                                  {t(
+                                    "products.details.variants.fields.optionValueEmpty"
+                                  )}
+                                </p>
+                              )}
+                              {errors?.optionValue && (
+                                <p className="text-xs text-destructive">
+                                  {errors.optionValue}
+                                </p>
+                              )}
+                            </div>
+                          </div>
+                        ) : (
+                          <div className="grid gap-4 md:grid-cols-2">
+                            <div className="space-y-2">
+                              <Label className="text-xs text-muted-foreground">
+                                {t("products.details.variants.fields.optionName")}
+                              </Label>
+                              <Input
+                                value={variant.optionName ?? ""}
+                                onChange={(event) =>
+                                  onVariantChange(index, "optionName", event.target.value)
+                                }
+                              />
+                              {errors?.optionName && (
+                                <p className="text-xs text-destructive">
+                                  {errors.optionName}
+                                </p>
+                              )}
+                            </div>
+                            <div className="space-y-2">
+                              <Label className="text-xs text-muted-foreground">
+                                {t("products.details.variants.fields.optionValue")}
+                              </Label>
+                              <Input
+                                value={variant.optionValue ?? ""}
+                                onChange={(event) =>
+                                  onVariantChange(index, "optionValue", event.target.value)
+                                }
+                              />
+                              {errors?.optionValue && (
+                                <p className="text-xs text-destructive">
+                                  {errors.optionValue}
+                                </p>
+                              )}
+                            </div>
+                          </div>
+                        )}
                       </div>
 
                       <div className="space-y-3">

--- a/packages/plugin-commerce-dashboard/src/modules/products/components/variants-section.tsx
+++ b/packages/plugin-commerce-dashboard/src/modules/products/components/variants-section.tsx
@@ -154,8 +154,27 @@ export function VariantsSection({
         {variants.length > 0 && (
           <div className="space-y-4">
             {variants.map((variant, index) => {
-              const legacyId = (variant as { _id?: string })._id;
-              const variantKey = variant.id ?? (legacyId?.trim() ? legacyId.trim() : undefined);
+              const variantKey = (() => {
+                if (typeof variant.id === "string" && variant.id.trim()) {
+                  return variant.id.trim();
+                }
+
+                if (typeof variant.id === "number") {
+                  return String(variant.id);
+                }
+
+                const legacyId = (variant as { _id?: unknown })._id;
+
+                if (typeof legacyId === "string" && legacyId.trim()) {
+                  return legacyId.trim();
+                }
+
+                if (typeof legacyId === "number") {
+                  return String(legacyId);
+                }
+
+                return undefined;
+              })();
 
               const price = getPrimaryPrice(variant, defaultCurrency);
               const selectedGallery = variant.gallery ?? [];

--- a/packages/plugin-commerce-dashboard/src/modules/products/components/variants-section.tsx
+++ b/packages/plugin-commerce-dashboard/src/modules/products/components/variants-section.tsx
@@ -1,6 +1,15 @@
-import { Plus, Trash2 } from "lucide-react";
+import { useMemo, useState } from "react";
+import {
+  Check,
+  ChevronDown,
+  ChevronUp,
+  Image as ImageIcon,
+  Plus,
+  Trash2,
+} from "lucide-react";
 import { useTranslation } from "react-i18next";
 import {
+  Badge,
   Button,
   Card,
   CardContent,
@@ -16,15 +25,25 @@ import type {
   ProductVariantModel,
 } from "@kitejs-cms/plugin-commerce-api";
 
-export type VariantState = (ProductVariantModel & {
-  id?: string;
-  allowBackorder?: boolean;
+export type VariantState = ProductVariantModel & {
   prices?: ProductPriceModel[];
-}) & Record<string, unknown>;
+};
+
+export type VariantFieldErrors = Partial<
+  Record<"title" | "sku" | "inventoryQuantity" | "gallery", string>
+>;
+
+export interface VariantGalleryOption {
+  id: string;
+  label: string;
+  url: string | null;
+}
 
 interface VariantsSectionProps {
   variants: VariantState[];
   defaultCurrency: string;
+  productGallery: VariantGalleryOption[];
+  variantErrors?: VariantFieldErrors[];
   onAddVariant: () => void;
   onRemoveVariant: (index: number) => void;
   onVariantChange: (
@@ -42,6 +61,7 @@ interface VariantsSectionProps {
     field: keyof ProductPriceModel,
     value: string
   ) => void;
+  onVariantGalleryChange: (index: number, gallery: string[]) => void;
 }
 
 const getPrimaryPrice = (
@@ -65,15 +85,40 @@ const getPrimaryPrice = (
   };
 };
 
+const formatPrice = (amount: number, currency: string) => {
+  try {
+    return new Intl.NumberFormat(undefined, {
+      style: "currency",
+      currency,
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    }).format(amount);
+  } catch (error) {
+    return `${currency} ${amount.toFixed(2)}`;
+  }
+};
+
 export function VariantsSection({
   variants,
   defaultCurrency,
+  productGallery,
+  variantErrors,
   onAddVariant,
   onRemoveVariant,
   onVariantChange,
   onVariantPriceChange,
+  onVariantGalleryChange,
 }: VariantsSectionProps) {
   const { t } = useTranslation("commerce");
+  const [expanded, setExpanded] = useState<number | null>(null);
+
+  const galleryLookup = useMemo(() => {
+    const map = new Map<string, VariantGalleryOption>();
+    productGallery.forEach((item) => {
+      map.set(item.id, item);
+    });
+    return map;
+  }, [productGallery]);
 
   const emptyState = (
     <div className="rounded-md border border-dashed border-muted-foreground/40 bg-muted/40 p-6 text-center text-sm text-muted-foreground">
@@ -110,176 +155,309 @@ export function VariantsSection({
           <div className="space-y-4">
             {variants.map((variant, index) => {
               const price = getPrimaryPrice(variant, defaultCurrency);
+              const selectedGallery = variant.gallery ?? [];
+              const preview = selectedGallery.length
+                ? galleryLookup.get(selectedGallery[0])
+                : undefined;
+              const priceLabel = formatPrice(price.amount ?? 0, price.currencyCode);
+              const inventoryLabel =
+                typeof variant.inventoryQuantity === "number" &&
+                variant.inventoryQuantity > 0
+                  ? t("products.details.variants.preview.inventoryCount", {
+                      count: variant.inventoryQuantity,
+                    })
+                  : t("products.details.variants.preview.inventoryFallback");
+              const isExpanded = expanded === index;
+              const errors = variantErrors?.[index];
+
+              const toggleGallerySelection = (assetId: string) => {
+                if (selectedGallery.includes(assetId)) {
+                  onVariantGalleryChange(
+                    index,
+                    selectedGallery.filter((entry) => entry !== assetId)
+                  );
+                } else {
+                  onVariantGalleryChange(index, [...selectedGallery, assetId]);
+                }
+              };
 
               return (
                 <div
                   key={variant.id ?? `${index}`}
-                  className="space-y-4 rounded-xl border border-border bg-background p-4 shadow-sm"
+                  className="overflow-hidden rounded-xl border border-border bg-background shadow-sm"
                 >
-                  <div className="flex items-center justify-between">
-                    <h4 className="text-sm font-semibold">
-                      {t("products.details.variants.itemTitle", { index: index + 1 })}
-                    </h4>
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="icon"
-                      className="text-destructive hover:text-destructive"
-                      onClick={() => onRemoveVariant(index)}
-                      aria-label={t("products.details.variants.remove")}
-                    >
-                      <Trash2 className="h-4 w-4" />
-                    </Button>
-                  </div>
-
-                  <div className="grid gap-4 md:grid-cols-2">
-                    <div className="space-y-2">
-                      <Label htmlFor={`variant-title-${index}`}>
-                        {t("products.details.variants.fields.name")}
-                      </Label>
-                      <Input
-                        id={`variant-title-${index}`}
-                        value={(variant.title as string) ?? ""}
-                        onChange={(event) =>
-                          onVariantChange(index, "title", event.target.value)
-                        }
-                      />
-                    </div>
-                    <div className="space-y-2">
-                      <Label htmlFor={`variant-sku-${index}`}>
-                        {t("products.details.variants.fields.sku")}
-                      </Label>
-                      <Input
-                        id={`variant-sku-${index}`}
-                        value={(variant.sku as string) ?? ""}
-                        onChange={(event) =>
-                          onVariantChange(index, "sku", event.target.value)
-                        }
-                      />
-                    </div>
-                    <div className="space-y-2">
-                      <Label htmlFor={`variant-barcode-${index}`}>
-                        {t("products.details.variants.fields.barcode")}
-                      </Label>
-                      <Input
-                        id={`variant-barcode-${index}`}
-                        value={(variant.barcode as string) ?? ""}
-                        onChange={(event) =>
-                          onVariantChange(index, "barcode", event.target.value)
-                        }
-                      />
-                    </div>
-                    <div className="space-y-2">
-                      <Label htmlFor={`variant-inventory-${index}`}>
-                        {t("products.details.variants.fields.inventory")}
-                      </Label>
-                      <Input
-                        id={`variant-inventory-${index}`}
-                        type="number"
-                        min={0}
-                        value={
-                          typeof variant.inventoryQuantity === "number"
-                            ? variant.inventoryQuantity
-                            : ""
-                        }
-                        onChange={(event) =>
-                          onVariantChange(
-                            index,
-                            "inventoryQuantity",
-                            event.target.value === ""
-                              ? undefined
-                              : Number(event.target.value)
-                          )
-                        }
-                      />
-                    </div>
-                  </div>
-
-                  <div className="grid gap-4 md:grid-cols-3">
-                    <div className="space-y-2">
-                      <Label htmlFor={`variant-price-${index}`}>
-                        {t("products.details.variants.fields.price")}
-                      </Label>
-                      <Input
-                        id={`variant-price-${index}`}
-                        type="number"
-                        min={0}
-                        step="0.01"
-                        value={
-                          typeof price.amount === "number" ? price.amount : ""
-                        }
-                        onChange={(event) =>
-                          onVariantPriceChange(
-                            index,
-                            "amount",
-                            event.target.value
-                          )
-                        }
-                      />
-                    </div>
-                    <div className="space-y-2">
-                      <Label htmlFor={`variant-compare-${index}`}>
-                        {t("products.details.variants.fields.compareAt")}
-                      </Label>
-                      <Input
-                        id={`variant-compare-${index}`}
-                        type="number"
-                        min={0}
-                        step="0.01"
-                        value={
-                          typeof price.compareAtAmount === "number"
-                            ? price.compareAtAmount
-                            : ""
-                        }
-                        onChange={(event) =>
-                          onVariantPriceChange(
-                            index,
-                            "compareAtAmount",
-                            event.target.value
-                          )
-                        }
-                      />
-                    </div>
-                    <div className="space-y-2">
-                      <Label htmlFor={`variant-currency-${index}`}>
-                        {t("products.details.variants.fields.currency")}
-                      </Label>
-                      <Input
-                        id={`variant-currency-${index}`}
-                        value={price.currencyCode ?? defaultCurrency}
-                        maxLength={3}
-                        onChange={(event) =>
-                          onVariantPriceChange(
-                            index,
-                            "currencyCode",
-                            event.target.value
-                          )
-                        }
-                      />
-                    </div>
-                  </div>
-
-                  <div className="rounded-md border p-4">
-                    <div className="flex items-center justify-between">
-                      <div className="pr-4">
-                        <p className="text-sm font-medium">
-                          {t("products.details.variants.fields.backorder")}
-                        </p>
-                        <p className="text-xs text-muted-foreground">
-                          {t(
-                            "products.details.variants.fields.backorderDescription"
-                          )}
-                        </p>
+                  <button
+                    type="button"
+                    className="flex w-full items-center justify-between gap-4 px-4 py-3 text-left transition-colors hover:bg-muted/50"
+                    onClick={() =>
+                      setExpanded((prev) => (prev === index ? null : index))
+                    }
+                    aria-expanded={isExpanded}
+                  >
+                    <div className="flex items-center gap-3">
+                      <div className="flex h-12 w-12 items-center justify-center overflow-hidden rounded-md border bg-muted">
+                        {preview?.url ? (
+                          <img
+                            src={preview.url}
+                            alt={preview.label}
+                            className="h-full w-full object-cover"
+                          />
+                        ) : (
+                          <ImageIcon className="h-5 w-5 text-muted-foreground" />
+                        )}
                       </div>
-                      <Switch
-                        id={`variant-backorder-${index}`}
-                        checked={Boolean(variant.allowBackorder)}
-                        onCheckedChange={(checked) =>
-                          onVariantChange(index, "allowBackorder", checked)
-                        }
-                      />
+                      <div className="flex flex-col gap-1">
+                        <span className="text-sm font-medium">
+                          {variant.title?.trim() ||
+                            t("products.details.variants.preview.untitled")}
+                        </span>
+                        <span className="text-xs text-muted-foreground">
+                          {variant.sku?.trim() ||
+                            t("products.details.variants.preview.missingSku")}
+                        </span>
+                      </div>
                     </div>
-                  </div>
+                    <div className="flex items-center gap-3">
+                      <div className="flex flex-col items-end">
+                        <Badge variant="outline" className="text-xs font-normal">
+                          {priceLabel}
+                        </Badge>
+                        <span className="text-xs text-muted-foreground">
+                          {inventoryLabel}
+                        </span>
+                      </div>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon"
+                        className="h-8 w-8 text-destructive hover:text-destructive"
+                        onClick={(event) => {
+                          event.stopPropagation();
+                          onRemoveVariant(index);
+                        }}
+                        aria-label={t("products.details.variants.remove")}
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </Button>
+                      {isExpanded ? (
+                        <ChevronUp className="h-4 w-4 text-muted-foreground" />
+                      ) : (
+                        <ChevronDown className="h-4 w-4 text-muted-foreground" />
+                      )}
+                    </div>
+                  </button>
+
+                  {isExpanded && (
+                    <div className="space-y-5 border-t px-4 py-5">
+                      <div className="grid gap-4 md:grid-cols-2">
+                        <div className="space-y-2">
+                          <Label htmlFor={`variant-title-${index}`}>
+                            {t("products.details.variants.fields.name")}
+                          </Label>
+                          <Input
+                            id={`variant-title-${index}`}
+                            value={variant.title ?? ""}
+                            aria-invalid={Boolean(errors?.title)}
+                            onChange={(event) =>
+                              onVariantChange(index, "title", event.target.value)
+                            }
+                          />
+                          {errors?.title && (
+                            <p className="text-xs text-destructive">{errors.title}</p>
+                          )}
+                        </div>
+                        <div className="space-y-2">
+                          <Label htmlFor={`variant-sku-${index}`}>
+                            {t("products.details.variants.fields.sku")}
+                          </Label>
+                          <Input
+                            id={`variant-sku-${index}`}
+                            value={variant.sku ?? ""}
+                            aria-invalid={Boolean(errors?.sku)}
+                            onChange={(event) =>
+                              onVariantChange(index, "sku", event.target.value)
+                            }
+                          />
+                          {errors?.sku && (
+                            <p className="text-xs text-destructive">{errors.sku}</p>
+                          )}
+                        </div>
+                        <div className="space-y-2">
+                          <Label htmlFor={`variant-barcode-${index}`}>
+                            {t("products.details.variants.fields.barcode")}
+                          </Label>
+                          <Input
+                            id={`variant-barcode-${index}`}
+                            value={variant.barcode ?? ""}
+                            onChange={(event) =>
+                              onVariantChange(index, "barcode", event.target.value)
+                            }
+                          />
+                        </div>
+                        <div className="space-y-2">
+                          <Label htmlFor={`variant-inventory-${index}`}>
+                            {t("products.details.variants.fields.inventory")}
+                          </Label>
+                          <Input
+                            id={`variant-inventory-${index}`}
+                            type="number"
+                            min={0}
+                            value={
+                              typeof variant.inventoryQuantity === "number"
+                                ? variant.inventoryQuantity
+                                : ""
+                            }
+                            onChange={(event) =>
+                              onVariantChange(
+                                index,
+                                "inventoryQuantity",
+                                event.target.value === ""
+                                  ? undefined
+                                  : Number(event.target.value)
+                              )
+                            }
+                          />
+                        </div>
+                      </div>
+
+                      <div className="grid gap-4 md:grid-cols-3">
+                        <div className="space-y-2">
+                          <Label htmlFor={`variant-price-${index}`}>
+                            {t("products.details.variants.fields.price")}
+                          </Label>
+                          <Input
+                            id={`variant-price-${index}`}
+                            type="number"
+                            min={0}
+                            step="0.01"
+                            value={
+                              typeof price.amount === "number" ? price.amount : ""
+                            }
+                            onChange={(event) =>
+                              onVariantPriceChange(
+                                index,
+                                "amount",
+                                event.target.value
+                              )
+                            }
+                          />
+                        </div>
+                        <div className="space-y-2">
+                          <Label htmlFor={`variant-compare-${index}`}>
+                            {t("products.details.variants.fields.compareAt")}
+                          </Label>
+                          <Input
+                            id={`variant-compare-${index}`}
+                            type="number"
+                            min={0}
+                            step="0.01"
+                            value={
+                              typeof price.compareAtAmount === "number"
+                                ? price.compareAtAmount
+                                : ""
+                            }
+                            onChange={(event) =>
+                              onVariantPriceChange(
+                                index,
+                                "compareAtAmount",
+                                event.target.value
+                              )
+                            }
+                          />
+                        </div>
+                        <div className="space-y-2">
+                          <Label htmlFor={`variant-currency-${index}`}>
+                            {t("products.details.variants.fields.currency")}
+                          </Label>
+                          <Input
+                            id={`variant-currency-${index}`}
+                            value={price.currencyCode ?? defaultCurrency}
+                            maxLength={3}
+                            onChange={(event) =>
+                              onVariantPriceChange(
+                                index,
+                                "currencyCode",
+                                event.target.value
+                              )
+                            }
+                          />
+                        </div>
+                      </div>
+
+                      <div className="space-y-3">
+                        <div>
+                          <Label>{t("products.details.variants.fields.media")}</Label>
+                          <p className="text-xs text-muted-foreground">
+                            {t("products.details.variants.fields.mediaDescription")}
+                          </p>
+                        </div>
+                        {productGallery.length > 0 ? (
+                          <div className="flex flex-wrap gap-3">
+                            {productGallery.map((asset) => {
+                              const isSelected = selectedGallery.includes(asset.id);
+                              return (
+                                <button
+                                  type="button"
+                                  key={asset.id}
+                                  className={`relative flex h-16 w-16 items-center justify-center overflow-hidden rounded-md border transition ${
+                                    isSelected
+                                      ? "border-primary ring-2 ring-primary"
+                                      : "border-muted bg-muted"
+                                  }`}
+                                  onClick={() => toggleGallerySelection(asset.id)}
+                                  aria-pressed={isSelected}
+                                >
+                                  {asset.url ? (
+                                    <img
+                                      src={asset.url}
+                                      alt={asset.label}
+                                      className="h-full w-full object-cover"
+                                    />
+                                  ) : (
+                                    <ImageIcon className="h-5 w-5 text-muted-foreground" />
+                                  )}
+                                  {isSelected && (
+                                    <span className="absolute right-1 top-1 rounded-full bg-primary p-1 text-primary-foreground">
+                                      <Check className="h-3 w-3" />
+                                    </span>
+                                  )}
+                                </button>
+                              );
+                            })}
+                          </div>
+                        ) : (
+                          <p className="text-xs text-muted-foreground">
+                            {t("products.details.variants.fields.mediaEmpty")}
+                          </p>
+                        )}
+                        {errors?.gallery && (
+                          <p className="text-xs text-destructive">{errors.gallery}</p>
+                        )}
+                      </div>
+
+                      <div className="rounded-md border p-4">
+                        <div className="flex items-center justify-between">
+                          <div className="pr-4">
+                            <p className="text-sm font-medium">
+                              {t("products.details.variants.fields.backorder")}
+                            </p>
+                            <p className="text-xs text-muted-foreground">
+                              {t(
+                                "products.details.variants.fields.backorderDescription"
+                              )}
+                            </p>
+                          </div>
+                          <Switch
+                            id={`variant-backorder-${index}`}
+                            checked={Boolean(variant.allowBackorder)}
+                            onCheckedChange={(checked) =>
+                              onVariantChange(index, "allowBackorder", checked)
+                            }
+                          />
+                        </div>
+                      </div>
+                    </div>
+                  )}
                 </div>
               );
             })}

--- a/packages/plugin-commerce-dashboard/src/modules/products/components/variants-section.tsx
+++ b/packages/plugin-commerce-dashboard/src/modules/products/components/variants-section.tsx
@@ -154,6 +154,9 @@ export function VariantsSection({
         {variants.length > 0 && (
           <div className="space-y-4">
             {variants.map((variant, index) => {
+              const legacyId = (variant as { _id?: string })._id;
+              const variantKey = variant.id ?? (legacyId?.trim() ? legacyId.trim() : undefined);
+
               const price = getPrimaryPrice(variant, defaultCurrency);
               const selectedGallery = variant.gallery ?? [];
               const preview = selectedGallery.length
@@ -183,7 +186,7 @@ export function VariantsSection({
 
               return (
                 <div
-                  key={variant.id ?? `${index}`}
+                  key={variantKey ?? `${index}`}
                   className="overflow-hidden rounded-xl border border-border bg-background shadow-sm"
                 >
                   <button

--- a/packages/plugin-commerce-dashboard/src/modules/products/components/variants-section.tsx
+++ b/packages/plugin-commerce-dashboard/src/modules/products/components/variants-section.tsx
@@ -1,0 +1,291 @@
+import { Plus, Trash2 } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import {
+  Button,
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  Input,
+  Label,
+  Separator,
+  Switch,
+} from "@kitejs-cms/dashboard-core";
+import type {
+  ProductPriceModel,
+  ProductVariantModel,
+} from "@kitejs-cms/plugin-commerce-api";
+
+export type VariantState = (ProductVariantModel & {
+  id?: string;
+  allowBackorder?: boolean;
+  prices?: ProductPriceModel[];
+}) & Record<string, unknown>;
+
+interface VariantsSectionProps {
+  variants: VariantState[];
+  defaultCurrency: string;
+  onAddVariant: () => void;
+  onRemoveVariant: (index: number) => void;
+  onVariantChange: (
+    index: number,
+    field:
+      | "title"
+      | "sku"
+      | "barcode"
+      | "inventoryQuantity"
+      | "allowBackorder",
+    value: string | number | boolean | undefined
+  ) => void;
+  onVariantPriceChange: (
+    index: number,
+    field: keyof ProductPriceModel,
+    value: string
+  ) => void;
+}
+
+const getPrimaryPrice = (
+  variant: VariantState,
+  fallbackCurrency: string
+): ProductPriceModel => {
+  const primary = variant.prices?.[0];
+
+  if (!primary) {
+    return {
+      currencyCode: fallbackCurrency,
+      amount: 0,
+      compareAtAmount: undefined,
+    };
+  }
+
+  return {
+    currencyCode: primary.currencyCode ?? fallbackCurrency,
+    amount: typeof primary.amount === "number" ? primary.amount : 0,
+    compareAtAmount: primary.compareAtAmount,
+  };
+};
+
+export function VariantsSection({
+  variants,
+  defaultCurrency,
+  onAddVariant,
+  onRemoveVariant,
+  onVariantChange,
+  onVariantPriceChange,
+}: VariantsSectionProps) {
+  const { t } = useTranslation("commerce");
+
+  const emptyState = (
+    <div className="rounded-md border border-dashed border-muted-foreground/40 bg-muted/40 p-6 text-center text-sm text-muted-foreground">
+      {t("products.details.variants.empty")}
+    </div>
+  );
+
+  return (
+    <Card className="w-full gap-0 py-0 shadow-neutral-50">
+      <CardHeader className="rounded-t-xl bg-secondary py-6 text-primary">
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <CardTitle>{t("products.details.variants.title")}</CardTitle>
+            <p className="text-sm text-primary/70">
+              {t("products.details.variants.description")}
+            </p>
+          </div>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="flex items-center gap-2"
+            onClick={onAddVariant}
+          >
+            <Plus className="h-4 w-4" />
+            {t("products.details.variants.add")}
+          </Button>
+        </div>
+      </CardHeader>
+      <Separator />
+      <CardContent className="space-y-4 p-4 md:p-6">
+        {variants.length === 0 && emptyState}
+        {variants.length > 0 && (
+          <div className="space-y-4">
+            {variants.map((variant, index) => {
+              const price = getPrimaryPrice(variant, defaultCurrency);
+
+              return (
+                <div
+                  key={variant.id ?? `${index}`}
+                  className="space-y-4 rounded-xl border border-border bg-background p-4 shadow-sm"
+                >
+                  <div className="flex items-center justify-between">
+                    <h4 className="text-sm font-semibold">
+                      {t("products.details.variants.itemTitle", { index: index + 1 })}
+                    </h4>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon"
+                      className="text-destructive hover:text-destructive"
+                      onClick={() => onRemoveVariant(index)}
+                      aria-label={t("products.details.variants.remove")}
+                    >
+                      <Trash2 className="h-4 w-4" />
+                    </Button>
+                  </div>
+
+                  <div className="grid gap-4 md:grid-cols-2">
+                    <div className="space-y-2">
+                      <Label htmlFor={`variant-title-${index}`}>
+                        {t("products.details.variants.fields.name")}
+                      </Label>
+                      <Input
+                        id={`variant-title-${index}`}
+                        value={(variant.title as string) ?? ""}
+                        onChange={(event) =>
+                          onVariantChange(index, "title", event.target.value)
+                        }
+                      />
+                    </div>
+                    <div className="space-y-2">
+                      <Label htmlFor={`variant-sku-${index}`}>
+                        {t("products.details.variants.fields.sku")}
+                      </Label>
+                      <Input
+                        id={`variant-sku-${index}`}
+                        value={(variant.sku as string) ?? ""}
+                        onChange={(event) =>
+                          onVariantChange(index, "sku", event.target.value)
+                        }
+                      />
+                    </div>
+                    <div className="space-y-2">
+                      <Label htmlFor={`variant-barcode-${index}`}>
+                        {t("products.details.variants.fields.barcode")}
+                      </Label>
+                      <Input
+                        id={`variant-barcode-${index}`}
+                        value={(variant.barcode as string) ?? ""}
+                        onChange={(event) =>
+                          onVariantChange(index, "barcode", event.target.value)
+                        }
+                      />
+                    </div>
+                    <div className="space-y-2">
+                      <Label htmlFor={`variant-inventory-${index}`}>
+                        {t("products.details.variants.fields.inventory")}
+                      </Label>
+                      <Input
+                        id={`variant-inventory-${index}`}
+                        type="number"
+                        min={0}
+                        value={
+                          typeof variant.inventoryQuantity === "number"
+                            ? variant.inventoryQuantity
+                            : ""
+                        }
+                        onChange={(event) =>
+                          onVariantChange(
+                            index,
+                            "inventoryQuantity",
+                            event.target.value === ""
+                              ? undefined
+                              : Number(event.target.value)
+                          )
+                        }
+                      />
+                    </div>
+                  </div>
+
+                  <div className="grid gap-4 md:grid-cols-3">
+                    <div className="space-y-2">
+                      <Label htmlFor={`variant-price-${index}`}>
+                        {t("products.details.variants.fields.price")}
+                      </Label>
+                      <Input
+                        id={`variant-price-${index}`}
+                        type="number"
+                        min={0}
+                        step="0.01"
+                        value={
+                          typeof price.amount === "number" ? price.amount : ""
+                        }
+                        onChange={(event) =>
+                          onVariantPriceChange(
+                            index,
+                            "amount",
+                            event.target.value
+                          )
+                        }
+                      />
+                    </div>
+                    <div className="space-y-2">
+                      <Label htmlFor={`variant-compare-${index}`}>
+                        {t("products.details.variants.fields.compareAt")}
+                      </Label>
+                      <Input
+                        id={`variant-compare-${index}`}
+                        type="number"
+                        min={0}
+                        step="0.01"
+                        value={
+                          typeof price.compareAtAmount === "number"
+                            ? price.compareAtAmount
+                            : ""
+                        }
+                        onChange={(event) =>
+                          onVariantPriceChange(
+                            index,
+                            "compareAtAmount",
+                            event.target.value
+                          )
+                        }
+                      />
+                    </div>
+                    <div className="space-y-2">
+                      <Label htmlFor={`variant-currency-${index}`}>
+                        {t("products.details.variants.fields.currency")}
+                      </Label>
+                      <Input
+                        id={`variant-currency-${index}`}
+                        value={price.currencyCode ?? defaultCurrency}
+                        maxLength={3}
+                        onChange={(event) =>
+                          onVariantPriceChange(
+                            index,
+                            "currencyCode",
+                            event.target.value
+                          )
+                        }
+                      />
+                    </div>
+                  </div>
+
+                  <div className="rounded-md border p-4">
+                    <div className="flex items-center justify-between">
+                      <div className="pr-4">
+                        <p className="text-sm font-medium">
+                          {t("products.details.variants.fields.backorder")}
+                        </p>
+                        <p className="text-xs text-muted-foreground">
+                          {t(
+                            "products.details.variants.fields.backorderDescription"
+                          )}
+                        </p>
+                      </div>
+                      <Switch
+                        id={`variant-backorder-${index}`}
+                        checked={Boolean(variant.allowBackorder)}
+                        onCheckedChange={(checked) =>
+                          onVariantChange(index, "allowBackorder", checked)
+                        }
+                      />
+                    </div>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/packages/plugin-commerce-dashboard/src/modules/products/hooks/product-details.types.ts
+++ b/packages/plugin-commerce-dashboard/src/modules/products/hooks/product-details.types.ts
@@ -1,0 +1,18 @@
+import type {
+  ProductResponseDetailsModel,
+  ProductTranslationModel,
+} from "@kitejs-cms/plugin-commerce-api";
+import type { MediaSource } from "./use-product-media";
+
+export type ProductDetailsState = Omit<
+  ProductResponseDetailsModel,
+  "gallery" | "thumbnail"
+> & {
+  gallery: MediaSource[];
+  thumbnail?: string | null;
+};
+
+export type ProductTranslationCandidate = {
+  lang: string;
+  translation: ProductTranslationModel;
+};

--- a/packages/plugin-commerce-dashboard/src/modules/products/hooks/product-details.utils.ts
+++ b/packages/plugin-commerce-dashboard/src/modules/products/hooks/product-details.utils.ts
@@ -1,0 +1,240 @@
+import type { ProductTranslationModel } from "@kitejs-cms/plugin-commerce-api";
+import type { VariantGalleryOption } from "../components/variants-section";
+import { type ProductDetailsState } from "./product-details.types";
+import type { MediaSource } from "./use-product-media";
+
+export const arraysEqual = (a: string[], b: string[]) =>
+  a.length === b.length && a.every((value, index) => value === b[index]);
+
+export const generateSlug = (title: string) =>
+  title
+    .toLowerCase()
+    .trim()
+    .replace(/[\s\W-]+/g, "-");
+
+export const slugifyOptionHandle = (value: string) =>
+  value
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+
+export const formatOptionDisplayName = (value: string) =>
+  value
+    .split(/[-_\s]+/)
+    .filter(Boolean)
+    .map((segment) => segment[0]?.toUpperCase() + segment.slice(1))
+    .join(" ");
+
+export const extractAssetId = (
+  source: MediaSource | undefined | null
+): string | null => {
+  if (!source) return null;
+  if (typeof source === "string") return source;
+  return (
+    source.assetId ??
+    source.id ??
+    source._id ??
+    source.path ??
+    null
+  );
+};
+
+export const mapAssetIdsToSources = (
+  assetIds: string[],
+  previous: MediaSource[]
+): MediaSource[] => {
+  if (!assetIds.length) return [];
+
+  const lookup = new Map<string, MediaSource>();
+  previous.forEach((entry) => {
+    const key = extractAssetId(entry);
+    if (key) {
+      lookup.set(key, entry);
+    }
+  });
+
+  return assetIds.map((id) => lookup.get(id) ?? id);
+};
+
+export const isLikelyExternalUrl = (value: string) => /^https?:\/\//i.test(value);
+
+const getUrlPath = (value: string): string | null => {
+  if (!value) return null;
+
+  try {
+    const url = new URL(value);
+    return url.pathname;
+  } catch (error) {
+    const normalized = value.split("?")[0];
+    return normalized.startsWith("/") ? normalized : null;
+  }
+};
+
+const findGalleryAssetIdByUrl = (
+  gallery: MediaSource[],
+  url: string
+): string | null => {
+  const targetPath = getUrlPath(url);
+  if (!targetPath) return null;
+
+  for (const entry of gallery) {
+    if (!entry) continue;
+
+    if (typeof entry === "string") {
+      if (!isLikelyExternalUrl(entry)) continue;
+      const entryPath = getUrlPath(entry);
+      if (entryPath && entryPath === targetPath) {
+        // String entries don't provide a stable asset identifier, so skip.
+        continue;
+      }
+      continue;
+    }
+
+    const urlsToCompare: string[] = [];
+    if (typeof entry.url === "string") {
+      urlsToCompare.push(entry.url);
+    }
+    const previewUrl = (entry as { previewUrl?: string | null }).previewUrl;
+    if (typeof previewUrl === "string") {
+      urlsToCompare.push(previewUrl);
+    }
+
+    for (const candidate of urlsToCompare) {
+      const candidatePath = getUrlPath(candidate);
+      if (candidatePath && candidatePath === targetPath) {
+        const assetId = extractAssetId(entry);
+        if (assetId) return assetId;
+      }
+    }
+
+    const entryPath = (entry as { path?: string | null }).path;
+    if (typeof entryPath === "string" && targetPath.endsWith(entryPath)) {
+      const assetId = extractAssetId(entry);
+      if (assetId) return assetId;
+    }
+  }
+
+  return null;
+};
+
+export const normalizeThumbnailIdentifier = (
+  thumbnail: string | null | undefined,
+  gallery: MediaSource[]
+): string | null => {
+  if (!thumbnail) return null;
+  if (!isLikelyExternalUrl(thumbnail)) return thumbnail;
+
+  return findGalleryAssetIdByUrl(gallery, thumbnail);
+};
+
+export const hydrateProductDetails = (
+  product: ProductDetailsState
+): ProductDetailsState => {
+  const gallery = (product.gallery ?? []) as MediaSource[];
+  const normalizedThumbnail = normalizeThumbnailIdentifier(
+    product.thumbnail ?? null,
+    gallery
+  );
+
+  const normalizedOptions = (product.options ?? [])
+    .map((option, index) => {
+      const trimmedName = option?.name?.trim() ?? "";
+      const slug = trimmedName
+        ? slugifyOptionHandle(trimmedName)
+        : slugifyOptionHandle(option?.displayName ?? "");
+
+      const displayName = option?.displayName?.trim();
+
+      const values = Array.isArray(option?.values)
+        ? option.values
+            .map((value) => value?.trim())
+            .filter((value): value is string => Boolean(value))
+        : [];
+
+      return {
+        name: slug || `option-${index + 1}`,
+        displayName:
+          displayName && displayName.length > 0
+            ? displayName
+            : trimmedName
+              ? formatOptionDisplayName(trimmedName)
+              : `Option ${index + 1}`,
+        values,
+        position:
+          typeof option?.position === "number" ? option.position : index,
+      } satisfies ProductDetailsState["options"][number];
+    })
+    .sort((a, b) => a.position - b.position);
+
+  const normalizedVariants = (product.variants ?? []).map((variant) => ({
+    ...variant,
+    optionName: variant.optionName?.trim() ?? undefined,
+    optionValue: variant.optionValue?.trim() ?? undefined,
+    gallery: Array.isArray(variant.gallery)
+      ? variant.gallery.filter(
+          (id): id is string => typeof id === "string" && Boolean(id)
+        )
+      : [],
+  }));
+
+  return {
+    ...product,
+    gallery,
+    thumbnail: normalizedThumbnail ?? product.thumbnail ?? null,
+    options: normalizedOptions,
+    variants: normalizedVariants,
+  };
+};
+
+export const buildVariantGalleryOptions = (
+  localData: ProductDetailsState | null,
+  languages: string[],
+  productGallery: MediaSource[]
+): VariantGalleryOption[] => {
+  if (!localData) return [];
+
+  return (productGallery ?? [])
+    .map((entry) => {
+      const assetId = extractAssetId(entry);
+      if (!assetId) return null;
+
+      if (typeof entry === "string") {
+        return {
+          id: assetId,
+          label: assetId,
+          url: isLikelyExternalUrl(entry) ? entry : null,
+        } satisfies VariantGalleryOption;
+      }
+
+      const localizedLabel = languages.reduce<string | undefined>((acc, lang) => {
+        if (acc) return acc;
+        const title = entry.title?.[lang]?.trim();
+        if (title) return title;
+        const alt = entry.alt?.[lang]?.trim();
+        if (alt) return alt;
+        return acc;
+      }, undefined);
+
+      return {
+        id: assetId,
+        label: localizedLabel ?? entry.name ?? entry.path ?? assetId ?? "",
+        url: entry.url ?? null,
+      } satisfies VariantGalleryOption;
+    })
+    .filter((option): option is VariantGalleryOption => option !== null);
+};
+
+export const getTranslationCandidate = (
+  translations: Record<string, ProductTranslationModel>,
+  lang?: string
+) => {
+  if (!lang) return null;
+  const translation = translations[lang];
+  if (translation?.title?.trim() && translation?.slug?.trim()) {
+    return { lang, translation } as const;
+  }
+  return null;
+};

--- a/packages/plugin-commerce-dashboard/src/modules/products/hooks/use-product-details.ts
+++ b/packages/plugin-commerce-dashboard/src/modules/products/hooks/use-product-details.ts
@@ -461,6 +461,21 @@ export function useProductDetails() {
 
       const normalizedVariants = (localData.variants ?? []).map(
         (variant, variantIndex) => {
+          const variantIdCandidate = (() => {
+            const variantWithId = variant as ProductVariantModel;
+            if (typeof variantWithId.id === "string" && variantWithId.id.trim()) {
+              return variantWithId.id.trim();
+            }
+
+            const legacyId = (variant as { _id?: unknown })._id;
+
+            if (typeof legacyId === "string" && legacyId.trim()) {
+              return legacyId.trim();
+            }
+
+            return undefined;
+          })();
+
           const normalizedPrices = (variant.prices ?? []).map((price) => ({
             currencyCode: price.currencyCode ?? defaultCurrency,
             amount:
@@ -483,7 +498,7 @@ export function useProductDetails() {
             variant.optionValue?.trim() || `${optionName}-${variantIndex + 1}`;
 
           return {
-            id: variant.id,
+            id: variantIdCandidate,
             title: variant.title ?? "",
             sku: variant.sku ?? "",
             barcode: variant.barcode,

--- a/packages/plugin-commerce-dashboard/src/modules/products/hooks/use-product-details.ts
+++ b/packages/plugin-commerce-dashboard/src/modules/products/hooks/use-product-details.ts
@@ -1611,6 +1611,6 @@ export function useProductDetails() {
     onOptionValueRemove,
     variantErrors,
     variantGalleryOptions,
-    productOptions: localData.options ?? [],
+    productOptions: localData?.options ?? [],
   };
 }

--- a/packages/plugin-commerce-dashboard/src/modules/products/hooks/use-product-details.ts
+++ b/packages/plugin-commerce-dashboard/src/modules/products/hooks/use-product-details.ts
@@ -786,7 +786,6 @@ export function useProductDetails() {
     setLocalData,
     setHasChanges,
     setVariantErrors,
-    t,
   });
 
   const {

--- a/packages/plugin-commerce-dashboard/src/modules/products/hooks/use-product-details.ts
+++ b/packages/plugin-commerce-dashboard/src/modules/products/hooks/use-product-details.ts
@@ -12,6 +12,7 @@ import type {
   ProductUpsertModel,
   ProductVariantModel,
   ProductSeoModel,
+  ProductTranslationModel,
 } from "@kitejs-cms/plugin-commerce-api";
 import { useProductOptions } from "./use-product-options";
 import { useProductVariants } from "./use-product-variants";

--- a/packages/plugin-commerce-dashboard/src/modules/products/hooks/use-product-details.ts
+++ b/packages/plugin-commerce-dashboard/src/modules/products/hooks/use-product-details.ts
@@ -30,6 +30,22 @@ const generateSlug = (title: string) =>
     .trim()
     .replace(/[\s\W-]+/g, "-");
 
+const slugifyOptionHandle = (value: string) =>
+  value
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+
+const formatOptionDisplayName = (value: string) =>
+  value
+    .split(/[-_\s]+/)
+    .filter(Boolean)
+    .map((segment) => segment[0]?.toUpperCase() + segment.slice(1))
+    .join(" ");
+
 const getTranslationCandidate = (
   translations: Record<string, ProductTranslationModel>,
   lang?: string
@@ -159,10 +175,53 @@ const hydrateProductDetails = (
     gallery
   );
 
+  const normalizedOptions = (product.options ?? [])
+    .map((option, index) => {
+      const trimmedName = option?.name?.trim() ?? "";
+      const slug = trimmedName
+        ? slugifyOptionHandle(trimmedName)
+        : slugifyOptionHandle(option?.displayName ?? "");
+
+      const displayName = option?.displayName?.trim();
+
+      const values = Array.isArray(option?.values)
+        ? option.values
+            .map((value) => value?.trim())
+            .filter((value): value is string => Boolean(value))
+        : [];
+
+      return {
+        name: slug || `option-${index + 1}`,
+        displayName:
+          displayName && displayName.length > 0
+            ? displayName
+            : trimmedName
+              ? formatOptionDisplayName(trimmedName)
+              : `Option ${index + 1}`,
+        values,
+        position:
+          typeof option?.position === "number" ? option.position : index,
+      } satisfies ProductDetailsState["options"][number];
+    })
+    .sort((a, b) => a.position - b.position);
+
+  const normalizedVariants = (product.variants ?? []).map((variant) => ({
+    ...variant,
+    optionName: variant.optionName?.trim() ?? undefined,
+    optionValue: variant.optionValue?.trim() ?? undefined,
+    gallery: Array.isArray(variant.gallery)
+      ? variant.gallery.filter(
+          (id): id is string => typeof id === "string" && Boolean(id)
+        )
+      : [],
+  }));
+
   return {
     ...product,
     gallery,
     thumbnail: normalizedThumbnail ?? product.thumbnail ?? null,
+    options: normalizedOptions,
+    variants: normalizedVariants,
   };
 };
 
@@ -491,6 +550,42 @@ export function useProductDetails() {
         );
       }
 
+      const optionName = variant.optionName?.trim();
+      const optionValue = variant.optionValue?.trim();
+      const optionList = localData.options ?? [];
+      const hasConfiguredOptions = optionList.length > 0;
+      const option = optionName
+        ? optionList.find((entry) => entry.name === optionName)
+        : undefined;
+
+      if (!optionName) {
+        variantError.optionName = t(
+          "products.errors.variantOptionRequired",
+          "Select an option"
+        );
+      } else if (hasConfiguredOptions && !option) {
+        variantError.optionName = t(
+          "products.errors.variantOptionRequired",
+          "Select an option"
+        );
+      }
+
+      if (!optionValue) {
+        variantError.optionValue = t(
+          "products.errors.variantOptionValueRequired",
+          "Select a value"
+        );
+      } else if (
+        hasConfiguredOptions &&
+        option?.values?.length &&
+        !option.values.includes(optionValue)
+      ) {
+        variantError.optionValue = t(
+          "products.errors.variantOptionValueInvalid",
+          "Select a valid option value"
+        );
+      }
+
       if (Object.keys(variantError).length > 0) {
         hasVariantValidationErrors = true;
         nextVariantErrors[index] = variantError;
@@ -536,6 +631,43 @@ export function useProductDetails() {
         .map((entry) => extractAssetId(entry))
         .filter((id): id is string => Boolean(id));
 
+      const uniqueOptionHandles = new Set<string>();
+      const normalizedOptions = (localData.options ?? []).map((option, index) => {
+        const trimmedDisplayName = option.displayName?.trim();
+        const handleSource =
+          option.name?.trim() || trimmedDisplayName || `option-${index + 1}`;
+        const baseName =
+          slugifyOptionHandle(handleSource) || `option-${index + 1}`;
+        let name = baseName;
+        let attempt = 1;
+        while (uniqueOptionHandles.has(name)) {
+          name = `${baseName}-${++attempt}`;
+        }
+        uniqueOptionHandles.add(name);
+        const displayName =
+          trimmedDisplayName && trimmedDisplayName.length > 0
+            ? trimmedDisplayName
+            : formatOptionDisplayName(handleSource) || `Option ${index + 1}`;
+        const values = Array.from(
+          new Set(
+            (option.values ?? [])
+              .map((value) => value?.trim())
+              .filter((value): value is string => Boolean(value))
+          )
+        );
+
+        return {
+          name,
+          displayName,
+          values,
+          position: index,
+        } satisfies ProductDetailsState["options"][number];
+      });
+
+      const optionLookup = new Map(
+        normalizedOptions.map((option) => [option.name, option])
+      );
+
       const normalizedVariants = (localData.variants ?? []).map(
         (variant, variantIndex) => {
           const variantIdCandidate = (() => {
@@ -570,9 +702,28 @@ export function useProductDetails() {
             (id): id is string => typeof id === "string" && Boolean(id)
           );
 
-          const optionName = variant.optionName?.trim() || "default";
-          const optionValue =
-            variant.optionValue?.trim() || `${optionName}-${variantIndex + 1}`;
+          const optionNameCandidate = variant.optionName?.trim();
+
+          const optionMatch = optionNameCandidate
+            ? optionLookup.get(optionNameCandidate)
+            : undefined;
+
+          const fallbackOption = normalizedOptions[0];
+          const optionName = optionMatch?.name
+            ? optionMatch.name
+            : fallbackOption?.name ?? "default";
+
+          const optionValueCandidate = variant.optionValue?.trim();
+          const selectedOption = optionLookup.get(optionName);
+          let optionValue =
+            optionValueCandidate &&
+            selectedOption?.values.includes(optionValueCandidate)
+              ? optionValueCandidate
+              : selectedOption?.values?.[0];
+
+          if (!optionValue) {
+            optionValue = `${optionName}-${variantIndex + 1}`;
+          }
 
           return {
             id: variantIdCandidate,
@@ -611,11 +762,12 @@ export function useProductDetails() {
         seo: localData.translations[activeLang].seo,
         publishAt: localData.publishAt,
         expireAt: localData.expireAt,
-        collections: localData.collections ?? null,
-        gallery: galleryAssetIds,
-        thumbnail: thumbnailId ?? undefined,
-        variants: normalizedVariants,
-      };
+            collections: localData.collections ?? null,
+            gallery: galleryAssetIds,
+            thumbnail: thumbnailId ?? undefined,
+            variants: normalizedVariants,
+            options: normalizedOptions,
+          };
 
       const result = await fetchData("commerce/products", "POST", body);
 
@@ -824,7 +976,9 @@ export function useProductDetails() {
         | "sku"
         | "barcode"
         | "inventoryQuantity"
-        | "allowBackorder",
+        | "allowBackorder"
+        | "optionName"
+        | "optionValue",
       value: string | number | boolean | undefined
     ) => {
       setLocalData((prev) => {
@@ -858,6 +1012,45 @@ export function useProductDetails() {
           case "allowBackorder":
             updated.allowBackorder = Boolean(value);
             break;
+          case "optionName": {
+            const rawValue = typeof value === "string" ? value : "";
+            const normalizedValue = rawValue
+              ? slugifyOptionHandle(rawValue)
+              : "";
+            const availableOptions = prev.options ?? [];
+            const matchedOption = availableOptions.find(
+              (option) => option.name === rawValue || option.name === normalizedValue
+            );
+
+            if (matchedOption) {
+              updated.optionName = matchedOption.name;
+              if (
+                matchedOption.values?.length &&
+                matchedOption.values.includes(updated.optionValue ?? "")
+              ) {
+                // Keep current option value if it's still valid
+                updated.optionValue = updated.optionValue;
+              } else {
+                updated.optionValue = matchedOption.values?.[0];
+              }
+            } else {
+              updated.optionName =
+                normalizedValue && normalizedValue.length > 0
+                  ? normalizedValue
+                  : undefined;
+              // Preserve existing option value when working with custom handles
+            }
+            break;
+          }
+          case "optionValue": {
+            if (typeof value === "string") {
+              const trimmed = value.trim();
+              updated.optionValue = trimmed.length > 0 ? trimmed : undefined;
+            } else {
+              updated.optionValue = undefined;
+            }
+            break;
+          }
         }
 
         variants[index] = updated;
@@ -867,21 +1060,14 @@ export function useProductDetails() {
         if (!prev.length) return prev;
         const current = prev[index];
         if (!current) return prev;
-        if (
-          field !== "title" &&
-          field !== "sku" &&
-          field !== "inventoryQuantity"
-        ) {
-          return prev;
-        }
-
-        if (!current[field]) {
+        const fieldKey = field as keyof VariantFieldErrors;
+        if (!current[fieldKey]) {
           return prev;
         }
 
         const next = [...prev];
         const updatedErrors = { ...current } as VariantFieldErrors;
-        delete updatedErrors[field];
+        delete updatedErrors[fieldKey];
         next[index] = Object.keys(updatedErrors).length ? updatedErrors : {};
         return next;
       });
@@ -965,10 +1151,340 @@ export function useProductDetails() {
     []
   );
 
+  const onAddOption = useCallback(() => {
+    setLocalData((prev) => {
+      if (!prev) return prev;
+
+      const existingOptions = prev.options ?? [];
+      const position = existingOptions.length;
+      const defaultLabel = t("products.details.options.defaultName", {
+        index: position + 1,
+      });
+      const baseHandle = slugifyOptionHandle(defaultLabel) || `option-${position + 1}`;
+
+      let handle = baseHandle;
+      let attempt = 1;
+      const existingHandles = new Set(existingOptions.map((option) => option.name));
+      while (existingHandles.has(handle)) {
+        handle = `${baseHandle}-${++attempt}`;
+      }
+
+      const option: ProductDetailsState["options"][number] = {
+        name: handle,
+        displayName: defaultLabel,
+        values: [],
+        position,
+      };
+
+      return {
+        ...prev,
+        options: [...existingOptions, option],
+      };
+    });
+    setHasChanges(true);
+  }, [t]);
+
+  const onRemoveOption = useCallback(
+    (index: number) => {
+      const clearedIndexes = new Set<number>();
+      const missingOptionIndexes = new Set<number>();
+      const missingValueIndexes = new Set<number>();
+
+      setLocalData((prev) => {
+        if (!prev) return prev;
+        const options = [...(prev.options ?? [])];
+        const target = options[index];
+        if (!target) return prev;
+
+        options.splice(index, 1);
+
+        const normalizedOptions = options.map((option, optionIndex) => ({
+          ...option,
+          position: optionIndex,
+        }));
+
+        const fallbackOption = normalizedOptions[0];
+
+        const variants = (prev.variants ?? []).map((variant, variantIndex) => {
+          if (variant.optionName === target.name) {
+            if (fallbackOption?.name) {
+              const hasExistingValue = fallbackOption.values?.includes(
+                variant.optionValue ?? ""
+              );
+              const fallbackValue = hasExistingValue
+                ? variant.optionValue
+                : fallbackOption.values?.[0];
+
+              if (fallbackValue) {
+                clearedIndexes.add(variantIndex);
+              } else {
+                missingValueIndexes.add(variantIndex);
+              }
+
+              return {
+                ...variant,
+                optionName: fallbackOption.name,
+                optionValue: fallbackValue,
+              };
+            }
+
+            missingOptionIndexes.add(variantIndex);
+            missingValueIndexes.add(variantIndex);
+            return {
+              ...variant,
+              optionName: undefined,
+              optionValue: undefined,
+            };
+          }
+
+          return variant;
+        });
+
+        return {
+          ...prev,
+          options: normalizedOptions,
+          variants,
+        };
+      });
+
+      if (
+        clearedIndexes.size ||
+        missingOptionIndexes.size ||
+        missingValueIndexes.size
+      ) {
+        setVariantErrors((prev) => {
+          const next = [...prev];
+          clearedIndexes.forEach((idx) => {
+            while (next.length <= idx) {
+              next.push({});
+            }
+            const current = next[idx];
+            if (!current) return;
+            const updated = { ...current } as VariantFieldErrors;
+            delete updated.optionName;
+            delete updated.optionValue;
+            next[idx] = Object.keys(updated).length ? updated : {};
+          });
+
+          missingOptionIndexes.forEach((idx) => {
+            while (next.length <= idx) {
+              next.push({});
+            }
+            const current = next[idx] ?? {};
+            next[idx] = {
+              ...current,
+              optionName: t(
+                "products.errors.variantOptionRequired",
+                "Select an option"
+              ),
+              optionValue: t(
+                "products.errors.variantOptionValueRequired",
+                "Select a value"
+              ),
+            };
+          });
+
+          missingValueIndexes.forEach((idx) => {
+            while (next.length <= idx) {
+              next.push({});
+            }
+            if (missingOptionIndexes.has(idx)) return;
+            const current = next[idx] ?? {};
+            next[idx] = {
+              ...current,
+              optionValue: t(
+                "products.errors.variantOptionValueRequired",
+                "Select a value"
+              ),
+            };
+          });
+
+          return next;
+        });
+      }
+
+      setHasChanges(true);
+    },
+    [t]
+  );
+
+  const onOptionChange = useCallback(
+    (
+      index: number,
+      field: "name" | "displayName",
+      value: string
+    ) => {
+      setLocalData((prev) => {
+        if (!prev) return prev;
+        const options = [...(prev.options ?? [])];
+        const target = options[index];
+        if (!target) return prev;
+
+        const updatedOption = { ...target } as ProductDetailsState["options"][number];
+        if (field === "displayName") {
+          updatedOption.displayName = value;
+          const currentSlug = slugifyOptionHandle(target.displayName ?? "");
+          const currentHandle = target.name ?? "";
+          const nextSlug = slugifyOptionHandle(value);
+
+          if (!currentHandle || currentHandle === currentSlug) {
+            updatedOption.name = nextSlug || currentHandle;
+          }
+        } else {
+          const nextHandle = slugifyOptionHandle(value);
+          updatedOption.name = nextHandle;
+
+          const variants = (prev.variants ?? []).map((variant) => {
+            if (variant.optionName === target.name) {
+              return {
+                ...variant,
+                optionName: nextHandle,
+              };
+            }
+            return variant;
+          });
+
+          options[index] = {
+            ...updatedOption,
+            position: target.position,
+          };
+
+          return {
+            ...prev,
+            options,
+            variants,
+          };
+        }
+
+        options[index] = {
+          ...updatedOption,
+          position: target.position,
+        };
+
+        return {
+          ...prev,
+          options,
+        };
+      });
+
+      setHasChanges(true);
+    },
+    []
+  );
+
+  const onOptionValueAdd = useCallback(
+    (index: number, value: string) => {
+      setLocalData((prev) => {
+        if (!prev) return prev;
+        const options = [...(prev.options ?? [])];
+        const target = options[index];
+        if (!target) return prev;
+
+        const trimmedValue = value.trim();
+        if (!trimmedValue) return prev;
+
+        const existingValues = new Set(target.values ?? []);
+        if (existingValues.has(trimmedValue)) {
+          return prev;
+        }
+
+        const nextValues = [...(target.values ?? []), trimmedValue];
+
+        options[index] = {
+          ...target,
+          values: nextValues,
+        };
+
+        return {
+          ...prev,
+          options,
+        };
+      });
+
+      setHasChanges(true);
+    },
+    []
+  );
+
+  const onOptionValueRemove = useCallback(
+    (index: number, value: string) => {
+      const missingValueIndexes = new Set<number>();
+
+      setLocalData((prev) => {
+        if (!prev) return prev;
+        const options = [...(prev.options ?? [])];
+        const target = options[index];
+        if (!target) return prev;
+
+        const filteredValues = (target.values ?? []).filter(
+          (entry) => entry !== value
+        );
+
+        options[index] = {
+          ...target,
+          values: filteredValues,
+        };
+
+        const variants = (prev.variants ?? []).map((variant, variantIndex) => {
+          if (variant.optionName === target.name && variant.optionValue === value) {
+            const fallbackValue = filteredValues[0];
+            if (fallbackValue) {
+              return {
+                ...variant,
+                optionValue: fallbackValue,
+              };
+            }
+            missingValueIndexes.add(variantIndex);
+            return {
+              ...variant,
+              optionValue: undefined,
+            };
+          }
+          return variant;
+        });
+
+        return {
+          ...prev,
+          options,
+          variants,
+        };
+      });
+
+      if (missingValueIndexes.size) {
+        setVariantErrors((prev) => {
+          const next = [...prev];
+          missingValueIndexes.forEach((idx) => {
+            while (next.length <= idx) {
+              next.push({});
+            }
+            const current = next[idx] ?? {};
+            next[idx] = {
+              ...current,
+              optionValue: t(
+                "products.errors.variantOptionValueRequired",
+                "Select a value"
+              ),
+            };
+          });
+
+          return next;
+        });
+      }
+
+      setHasChanges(true);
+    },
+    [t]
+  );
+
   const onAddVariant = useCallback(() => {
     let didAdd = false;
     setLocalData((prev) => {
       if (!prev) return prev;
+
+      const primaryOption = prev.options?.[0];
+      const optionHandle = primaryOption?.name?.trim() || "default";
+      const initialOptionValue =
+        primaryOption?.values?.[0] ?? `${optionHandle}-${Date.now()}`;
 
       const variant: ProductDetailsState["variants"][number] = {
         id: undefined,
@@ -984,8 +1500,8 @@ export function useProductDetails() {
         inventoryQuantity: 0,
         allowBackorder: false,
         gallery: [],
-        optionName: "default",
-        optionValue: `default-${Date.now()}`,
+        optionName: optionHandle,
+        optionValue: initialOptionValue,
       } as ProductDetailsState["variants"][number];
 
       didAdd = true;
@@ -1088,7 +1604,13 @@ export function useProductDetails() {
     onVariantGalleryChange,
     onAddVariant,
     onRemoveVariant,
+    onAddOption,
+    onRemoveOption,
+    onOptionChange,
+    onOptionValueAdd,
+    onOptionValueRemove,
     variantErrors,
     variantGalleryOptions,
+    productOptions: localData.options ?? [],
   };
 }

--- a/packages/plugin-commerce-dashboard/src/modules/products/hooks/use-product-details.ts
+++ b/packages/plugin-commerce-dashboard/src/modules/products/hooks/use-product-details.ts
@@ -9,221 +9,26 @@ import {
 } from "@kitejs-cms/dashboard-core";
 import type {
   ProductResponseDetailsModel,
-  ProductTranslationModel,
   ProductUpsertModel,
-  ProductSeoModel,
-  ProductPriceModel,
   ProductVariantModel,
+  ProductSeoModel,
 } from "@kitejs-cms/plugin-commerce-api";
+import { useProductOptions } from "./use-product-options";
+import { useProductVariants } from "./use-product-variants";
+import {
+  arraysEqual,
+  extractAssetId,
+  formatOptionDisplayName,
+  generateSlug,
+  hydrateProductDetails,
+  mapAssetIdsToSources,
+  normalizeThumbnailIdentifier,
+  slugifyOptionHandle,
+  getTranslationCandidate,
+} from "./product-details.utils";
+import type { ProductDetailsState } from "./product-details.types";
 import type { MediaSource } from "./use-product-media";
-import type {
-  VariantFieldErrors,
-  VariantGalleryOption,
-} from "../components/variants-section";
-
-const arraysEqual = (a: string[], b: string[]) =>
-  a.length === b.length && a.every((value, index) => value === b[index]);
-
-const generateSlug = (title: string) =>
-  title
-    .toLowerCase()
-    .trim()
-    .replace(/[\s\W-]+/g, "-");
-
-const slugifyOptionHandle = (value: string) =>
-  value
-    .normalize("NFKD")
-    .replace(/[\u0300-\u036f]/g, "")
-    .toLowerCase()
-    .trim()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "");
-
-const formatOptionDisplayName = (value: string) =>
-  value
-    .split(/[-_\s]+/)
-    .filter(Boolean)
-    .map((segment) => segment[0]?.toUpperCase() + segment.slice(1))
-    .join(" ");
-
-const getTranslationCandidate = (
-  translations: Record<string, ProductTranslationModel>,
-  lang?: string
-) => {
-  if (!lang) return null;
-  const translation = translations[lang];
-  if (translation?.title?.trim() && translation?.slug?.trim()) {
-    return { lang, translation } as const;
-  }
-  return null;
-};
-
-type ProductDetailsState = Omit<
-  ProductResponseDetailsModel,
-  "gallery" | "thumbnail"
-> & {
-  gallery: MediaSource[];
-  thumbnail?: string | null;
-};
-
-const extractAssetId = (source: MediaSource | undefined | null): string | null => {
-  if (!source) return null;
-  if (typeof source === "string") return source;
-  return (
-    source.assetId ??
-    source.id ??
-    source._id ??
-    source.path ??
-    null
-  );
-};
-
-const mapAssetIdsToSources = (
-  assetIds: string[],
-  previous: MediaSource[]
-): MediaSource[] => {
-  if (!assetIds.length) return [];
-
-  const lookup = new Map<string, MediaSource>();
-  previous.forEach((entry) => {
-    const key = extractAssetId(entry);
-    if (key) {
-      lookup.set(key, entry);
-    }
-  });
-
-  return assetIds.map((id) => lookup.get(id) ?? id);
-};
-
-const isLikelyExternalUrl = (value: string) => /^https?:\/\//i.test(value);
-
-const getUrlPath = (value: string): string | null => {
-  if (!value) return null;
-
-  try {
-    const url = new URL(value);
-    return url.pathname;
-  } catch (error) {
-    const normalized = value.split("?")[0];
-    return normalized.startsWith("/") ? normalized : null;
-  }
-};
-
-const findGalleryAssetIdByUrl = (
-  gallery: MediaSource[],
-  url: string
-): string | null => {
-  const targetPath = getUrlPath(url);
-  if (!targetPath) return null;
-
-  for (const entry of gallery) {
-    if (!entry) continue;
-
-    if (typeof entry === "string") {
-      if (!isLikelyExternalUrl(entry)) continue;
-      const entryPath = getUrlPath(entry);
-      if (entryPath && entryPath === targetPath) {
-        // String entries don't provide a stable asset identifier, so skip.
-        continue;
-      }
-      continue;
-    }
-
-    const urlsToCompare: string[] = [];
-    if (typeof entry.url === "string") {
-      urlsToCompare.push(entry.url);
-    }
-    const previewUrl = (entry as { previewUrl?: string | null }).previewUrl;
-    if (typeof previewUrl === "string") {
-      urlsToCompare.push(previewUrl);
-    }
-
-    for (const candidate of urlsToCompare) {
-      const candidatePath = getUrlPath(candidate);
-      if (candidatePath && candidatePath === targetPath) {
-        const assetId = extractAssetId(entry);
-        if (assetId) return assetId;
-      }
-    }
-
-    const entryPath = (entry as { path?: string | null }).path;
-    if (typeof entryPath === "string" && targetPath.endsWith(entryPath)) {
-      const assetId = extractAssetId(entry);
-      if (assetId) return assetId;
-    }
-  }
-
-  return null;
-};
-
-const normalizeThumbnailIdentifier = (
-  thumbnail: string | null | undefined,
-  gallery: MediaSource[]
-): string | null => {
-  if (!thumbnail) return null;
-  if (!isLikelyExternalUrl(thumbnail)) return thumbnail;
-
-  return findGalleryAssetIdByUrl(gallery, thumbnail);
-};
-
-const hydrateProductDetails = (
-  product: ProductResponseDetailsModel
-): ProductDetailsState => {
-  const gallery = (product.gallery ?? []) as MediaSource[];
-  const normalizedThumbnail = normalizeThumbnailIdentifier(
-    product.thumbnail ?? null,
-    gallery
-  );
-
-  const normalizedOptions = (product.options ?? [])
-    .map((option, index) => {
-      const trimmedName = option?.name?.trim() ?? "";
-      const slug = trimmedName
-        ? slugifyOptionHandle(trimmedName)
-        : slugifyOptionHandle(option?.displayName ?? "");
-
-      const displayName = option?.displayName?.trim();
-
-      const values = Array.isArray(option?.values)
-        ? option.values
-            .map((value) => value?.trim())
-            .filter((value): value is string => Boolean(value))
-        : [];
-
-      return {
-        name: slug || `option-${index + 1}`,
-        displayName:
-          displayName && displayName.length > 0
-            ? displayName
-            : trimmedName
-              ? formatOptionDisplayName(trimmedName)
-              : `Option ${index + 1}`,
-        values,
-        position:
-          typeof option?.position === "number" ? option.position : index,
-      } satisfies ProductDetailsState["options"][number];
-    })
-    .sort((a, b) => a.position - b.position);
-
-  const normalizedVariants = (product.variants ?? []).map((variant) => ({
-    ...variant,
-    optionName: variant.optionName?.trim() ?? undefined,
-    optionValue: variant.optionValue?.trim() ?? undefined,
-    gallery: Array.isArray(variant.gallery)
-      ? variant.gallery.filter(
-          (id): id is string => typeof id === "string" && Boolean(id)
-        )
-      : [],
-  }));
-
-  return {
-    ...product,
-    gallery,
-    thumbnail: normalizedThumbnail ?? product.thumbnail ?? null,
-    options: normalizedOptions,
-    variants: normalizedVariants,
-  };
-};
+import type { VariantFieldErrors } from "../components/variants-section";
 
 const findTranslationForUpsert = (
   product: ProductDetailsState,
@@ -749,8 +554,14 @@ export function useProductDetails() {
         (localData.gallery ?? []) as MediaSource[]
       );
 
+      const upsertId = localData?.id?.trim()
+        ? localData.id.trim()
+        : id && id !== "create"
+          ? id
+          : undefined;
+
       const body: ProductUpsertModel = {
-        id: id && id !== "create" ? localData.id : undefined,
+        id: upsertId,
         language: activeLang,
         status: localData.status,
         slug: localData.translations[activeLang].slug,
@@ -934,7 +745,8 @@ export function useProductDetails() {
       const { lang, translation } = translationEntry;
 
       const body: ProductUpsertModel = {
-        id: updatedData.id,
+        id:
+          updatedData.id?.trim() || (id && id !== "create" ? id : undefined),
         language: lang,
         status: updatedData.status,
         slug: translation.slug,
@@ -965,620 +777,34 @@ export function useProductDetails() {
         throw error;
       }
     },
-    [activeLang, defaultLang, fetchData, localData, t]
+    [activeLang, defaultLang, fetchData, id, localData, t]
   );
 
-  const onVariantChange = useCallback(
-    (
-      index: number,
-      field:
-        | "title"
-        | "sku"
-        | "barcode"
-        | "inventoryQuantity"
-        | "allowBackorder"
-        | "optionName"
-        | "optionValue",
-      value: string | number | boolean | undefined
-    ) => {
-      setLocalData((prev) => {
-        if (!prev) return prev;
-        const variants = [...(prev.variants ?? [])];
-        const current = variants[index];
-        if (!current) return prev;
-
-        const updated = { ...current } as typeof current;
-
-        switch (field) {
-          case "title":
-          case "sku":
-          case "barcode":
-            updated[field] = (value as string) ?? "";
-            break;
-          case "inventoryQuantity": {
-            const numericValue =
-              typeof value === "number"
-                ? value
-                : value === undefined
-                  ? undefined
-                  : Number(value);
-
-            updated.inventoryQuantity =
-              numericValue === undefined || Number.isNaN(numericValue)
-                ? 0
-                : Math.max(0, Math.trunc(numericValue));
-            break;
-          }
-          case "allowBackorder":
-            updated.allowBackorder = Boolean(value);
-            break;
-          case "optionName": {
-            const rawValue = typeof value === "string" ? value : "";
-            const normalizedValue = rawValue
-              ? slugifyOptionHandle(rawValue)
-              : "";
-            const availableOptions = prev.options ?? [];
-            const matchedOption = availableOptions.find(
-              (option) => option.name === rawValue || option.name === normalizedValue
-            );
-
-            if (matchedOption) {
-              updated.optionName = matchedOption.name;
-              if (
-                matchedOption.values?.length &&
-                matchedOption.values.includes(updated.optionValue ?? "")
-              ) {
-                // Keep current option value if it's still valid
-                updated.optionValue = updated.optionValue;
-              } else {
-                updated.optionValue = matchedOption.values?.[0];
-              }
-            } else {
-              updated.optionName =
-                normalizedValue && normalizedValue.length > 0
-                  ? normalizedValue
-                  : undefined;
-              // Preserve existing option value when working with custom handles
-            }
-            break;
-          }
-          case "optionValue": {
-            if (typeof value === "string") {
-              const trimmed = value.trim();
-              updated.optionValue = trimmed.length > 0 ? trimmed : undefined;
-            } else {
-              updated.optionValue = undefined;
-            }
-            break;
-          }
-        }
-
-        variants[index] = updated;
-        return { ...prev, variants };
-      });
-      setVariantErrors((prev) => {
-        if (!prev.length) return prev;
-        const current = prev[index];
-        if (!current) return prev;
-        const fieldKey = field as keyof VariantFieldErrors;
-        if (!current[fieldKey]) {
-          return prev;
-        }
-
-        const next = [...prev];
-        const updatedErrors = { ...current } as VariantFieldErrors;
-        delete updatedErrors[fieldKey];
-        next[index] = Object.keys(updatedErrors).length ? updatedErrors : {};
-        return next;
-      });
-      setHasChanges(true);
-    },
-    []
-  );
-
-  const onVariantPriceChange = useCallback(
-    (index: number, field: keyof ProductPriceModel, value: string) => {
-      setLocalData((prev) => {
-        if (!prev) return prev;
-        const variants = [...(prev.variants ?? [])];
-        const current = variants[index];
-        if (!current) return prev;
-
-        const prices = [...(current.prices ?? [])];
-        const primary = {
-          currencyCode: defaultCurrency,
-          amount: 0,
-          compareAtAmount: undefined as number | undefined,
-          ...prices[0],
-        };
-
-        if (field === "currencyCode") {
-          primary.currencyCode = value
-            ? value.trim().toUpperCase().slice(0, 3)
-            : defaultCurrency;
-        }
-
-        if (field === "amount") {
-          const parsed = Number.parseFloat(value);
-          primary.amount = Number.isNaN(parsed) ? 0 : Math.max(0, parsed);
-        }
-
-        if (field === "compareAtAmount") {
-          const parsed = Number.parseFloat(value);
-          primary.compareAtAmount = Number.isNaN(parsed)
-            ? undefined
-            : Math.max(0, parsed);
-        }
-
-        prices[0] = primary;
-        variants[index] = { ...current, prices };
-        return { ...prev, variants };
-      });
-      setHasChanges(true);
-    },
-    [defaultCurrency]
-  );
-
-  const onVariantGalleryChange = useCallback(
-    (index: number, gallery: string[]) => {
-      setLocalData((prev) => {
-        if (!prev) return prev;
-        const variants = [...(prev.variants ?? [])];
-        const current = variants[index];
-        if (!current) return prev;
-
-        variants[index] = {
-          ...current,
-          gallery,
-        };
-
-        return { ...prev, variants };
-      });
-
-      setVariantErrors((prev) => {
-        if (!prev.length) return prev;
-        const current = prev[index];
-        if (!current?.gallery) return prev;
-        const next = [...prev];
-        const updated = { ...current } as VariantFieldErrors;
-        delete updated.gallery;
-        next[index] = Object.keys(updated).length ? updated : {};
-        return next;
-      });
-
-      setHasChanges(true);
-    },
-    []
-  );
-
-  const onAddOption = useCallback(() => {
-    setLocalData((prev) => {
-      if (!prev) return prev;
-
-      const existingOptions = prev.options ?? [];
-      const position = existingOptions.length;
-      const defaultLabel = t("products.details.options.defaultName", {
-        index: position + 1,
-      });
-      const baseHandle = slugifyOptionHandle(defaultLabel) || `option-${position + 1}`;
-
-      let handle = baseHandle;
-      let attempt = 1;
-      const existingHandles = new Set(existingOptions.map((option) => option.name));
-      while (existingHandles.has(handle)) {
-        handle = `${baseHandle}-${++attempt}`;
-      }
-
-      const option: ProductDetailsState["options"][number] = {
-        name: handle,
-        displayName: defaultLabel,
-        values: [],
-        position,
-      };
-
-      return {
-        ...prev,
-        options: [...existingOptions, option],
-      };
-    });
-    setHasChanges(true);
-  }, [t]);
-
-  const onRemoveOption = useCallback(
-    (index: number) => {
-      const clearedIndexes = new Set<number>();
-      const missingOptionIndexes = new Set<number>();
-      const missingValueIndexes = new Set<number>();
-
-      setLocalData((prev) => {
-        if (!prev) return prev;
-        const options = [...(prev.options ?? [])];
-        const target = options[index];
-        if (!target) return prev;
-
-        options.splice(index, 1);
-
-        const normalizedOptions = options.map((option, optionIndex) => ({
-          ...option,
-          position: optionIndex,
-        }));
-
-        const fallbackOption = normalizedOptions[0];
-
-        const variants = (prev.variants ?? []).map((variant, variantIndex) => {
-          if (variant.optionName === target.name) {
-            if (fallbackOption?.name) {
-              const hasExistingValue = fallbackOption.values?.includes(
-                variant.optionValue ?? ""
-              );
-              const fallbackValue = hasExistingValue
-                ? variant.optionValue
-                : fallbackOption.values?.[0];
-
-              if (fallbackValue) {
-                clearedIndexes.add(variantIndex);
-              } else {
-                missingValueIndexes.add(variantIndex);
-              }
-
-              return {
-                ...variant,
-                optionName: fallbackOption.name,
-                optionValue: fallbackValue,
-              };
-            }
-
-            missingOptionIndexes.add(variantIndex);
-            missingValueIndexes.add(variantIndex);
-            return {
-              ...variant,
-              optionName: undefined,
-              optionValue: undefined,
-            };
-          }
-
-          return variant;
-        });
-
-        return {
-          ...prev,
-          options: normalizedOptions,
-          variants,
-        };
-      });
-
-      if (
-        clearedIndexes.size ||
-        missingOptionIndexes.size ||
-        missingValueIndexes.size
-      ) {
-        setVariantErrors((prev) => {
-          const next = [...prev];
-          clearedIndexes.forEach((idx) => {
-            while (next.length <= idx) {
-              next.push({});
-            }
-            const current = next[idx];
-            if (!current) return;
-            const updated = { ...current } as VariantFieldErrors;
-            delete updated.optionName;
-            delete updated.optionValue;
-            next[idx] = Object.keys(updated).length ? updated : {};
-          });
-
-          missingOptionIndexes.forEach((idx) => {
-            while (next.length <= idx) {
-              next.push({});
-            }
-            const current = next[idx] ?? {};
-            next[idx] = {
-              ...current,
-              optionName: t(
-                "products.errors.variantOptionRequired",
-                "Select an option"
-              ),
-              optionValue: t(
-                "products.errors.variantOptionValueRequired",
-                "Select a value"
-              ),
-            };
-          });
-
-          missingValueIndexes.forEach((idx) => {
-            while (next.length <= idx) {
-              next.push({});
-            }
-            if (missingOptionIndexes.has(idx)) return;
-            const current = next[idx] ?? {};
-            next[idx] = {
-              ...current,
-              optionValue: t(
-                "products.errors.variantOptionValueRequired",
-                "Select a value"
-              ),
-            };
-          });
-
-          return next;
-        });
-      }
-
-      setHasChanges(true);
-    },
-    [t]
-  );
-
-  const onOptionChange = useCallback(
-    (
-      index: number,
-      field: "name" | "displayName",
-      value: string
-    ) => {
-      setLocalData((prev) => {
-        if (!prev) return prev;
-        const options = [...(prev.options ?? [])];
-        const target = options[index];
-        if (!target) return prev;
-
-        const updatedOption = { ...target } as ProductDetailsState["options"][number];
-        if (field === "displayName") {
-          updatedOption.displayName = value;
-          const currentSlug = slugifyOptionHandle(target.displayName ?? "");
-          const currentHandle = target.name ?? "";
-          const nextSlug = slugifyOptionHandle(value);
-
-          if (!currentHandle || currentHandle === currentSlug) {
-            updatedOption.name = nextSlug || currentHandle;
-          }
-        } else {
-          const nextHandle = slugifyOptionHandle(value);
-          updatedOption.name = nextHandle;
-
-          const variants = (prev.variants ?? []).map((variant) => {
-            if (variant.optionName === target.name) {
-              return {
-                ...variant,
-                optionName: nextHandle,
-              };
-            }
-            return variant;
-          });
-
-          options[index] = {
-            ...updatedOption,
-            position: target.position,
-          };
-
-          return {
-            ...prev,
-            options,
-            variants,
-          };
-        }
-
-        options[index] = {
-          ...updatedOption,
-          position: target.position,
-        };
-
-        return {
-          ...prev,
-          options,
-        };
-      });
-
-      setHasChanges(true);
-    },
-    []
-  );
-
-  const onOptionValueAdd = useCallback(
-    (index: number, value: string) => {
-      setLocalData((prev) => {
-        if (!prev) return prev;
-        const options = [...(prev.options ?? [])];
-        const target = options[index];
-        if (!target) return prev;
-
-        const trimmedValue = value.trim();
-        if (!trimmedValue) return prev;
-
-        const existingValues = new Set(target.values ?? []);
-        if (existingValues.has(trimmedValue)) {
-          return prev;
-        }
-
-        const nextValues = [...(target.values ?? []), trimmedValue];
-
-        options[index] = {
-          ...target,
-          values: nextValues,
-        };
-
-        return {
-          ...prev,
-          options,
-        };
-      });
-
-      setHasChanges(true);
-    },
-    []
-  );
-
-  const onOptionValueRemove = useCallback(
-    (index: number, value: string) => {
-      const missingValueIndexes = new Set<number>();
-
-      setLocalData((prev) => {
-        if (!prev) return prev;
-        const options = [...(prev.options ?? [])];
-        const target = options[index];
-        if (!target) return prev;
-
-        const filteredValues = (target.values ?? []).filter(
-          (entry) => entry !== value
-        );
-
-        options[index] = {
-          ...target,
-          values: filteredValues,
-        };
-
-        const variants = (prev.variants ?? []).map((variant, variantIndex) => {
-          if (variant.optionName === target.name && variant.optionValue === value) {
-            const fallbackValue = filteredValues[0];
-            if (fallbackValue) {
-              return {
-                ...variant,
-                optionValue: fallbackValue,
-              };
-            }
-            missingValueIndexes.add(variantIndex);
-            return {
-              ...variant,
-              optionValue: undefined,
-            };
-          }
-          return variant;
-        });
-
-        return {
-          ...prev,
-          options,
-          variants,
-        };
-      });
-
-      if (missingValueIndexes.size) {
-        setVariantErrors((prev) => {
-          const next = [...prev];
-          missingValueIndexes.forEach((idx) => {
-            while (next.length <= idx) {
-              next.push({});
-            }
-            const current = next[idx] ?? {};
-            next[idx] = {
-              ...current,
-              optionValue: t(
-                "products.errors.variantOptionValueRequired",
-                "Select a value"
-              ),
-            };
-          });
-
-          return next;
-        });
-      }
-
-      setHasChanges(true);
-    },
-    [t]
-  );
-
-  const onAddVariant = useCallback(() => {
-    let didAdd = false;
-    setLocalData((prev) => {
-      if (!prev) return prev;
-
-      const primaryOption = prev.options?.[0];
-      const optionHandle = primaryOption?.name?.trim() || "default";
-      const initialOptionValue =
-        primaryOption?.values?.[0] ?? `${optionHandle}-${Date.now()}`;
-
-      const variant: ProductDetailsState["variants"][number] = {
-        id: undefined,
-        title: "",
-        sku: "",
-        barcode: "",
-        prices: [
-          {
-            currencyCode: defaultCurrency,
-            amount: 0,
-          },
-        ],
-        inventoryQuantity: 0,
-        allowBackorder: false,
-        gallery: [],
-        optionName: optionHandle,
-        optionValue: initialOptionValue,
-      } as ProductDetailsState["variants"][number];
-
-      didAdd = true;
-
-      return {
-        ...prev,
-        variants: [...(prev.variants ?? []), variant],
-      };
-    });
-    if (didAdd) {
-      setVariantErrors((prev) => [...prev, {}]);
-    }
-    setHasChanges(true);
-  }, [defaultCurrency]);
-
-  const onRemoveVariant = useCallback((index: number) => {
-    let didRemove = false;
-    setLocalData((prev) => {
-      if (!prev) return prev;
-      const variants = [...(prev.variants ?? [])];
-      if (!variants[index]) return prev;
-      variants.splice(index, 1);
-      didRemove = true;
-      return { ...prev, variants };
-    });
-    if (didRemove) {
-      setVariantErrors((prev) => {
-        if (!prev.length) return prev;
-        const next = [...prev];
-        next.splice(index, 1);
-        return next;
-      });
-    }
-    setHasChanges(true);
-  }, []);
-
-  const variantGalleryOptions = useMemo<VariantGalleryOption[]>(() => {
-    if (!localData) return [];
-
-    const languages = [activeLang, defaultLang].filter(
-      (lang): lang is string => Boolean(lang)
-    );
-
-    return (localData.gallery ?? [])
-      .map((entry) => {
-        const assetId = extractAssetId(entry);
-        if (!assetId) return null;
-
-        if (typeof entry === "string") {
-          return {
-            id: assetId,
-            label: assetId,
-            url: isLikelyExternalUrl(entry) ? entry : null,
-          } satisfies VariantGalleryOption;
-        }
-
-        const localizedLabel = languages.reduce<string | undefined>(
-          (acc, lang) => {
-            if (acc) return acc;
-            const title = entry.title?.[lang]?.trim();
-            if (title) return title;
-            const alt = entry.alt?.[lang]?.trim();
-            if (alt) return alt;
-            return acc;
-          },
-          undefined
-        );
-
-        return {
-          id: assetId,
-          label:
-            localizedLabel ?? entry.name ?? entry.path ?? assetId ?? "",
-          url: entry.url ?? null,
-        } satisfies VariantGalleryOption;
-      })
-      .filter((option): option is VariantGalleryOption => option !== null);
-  }, [localData, activeLang, defaultLang]);
+  const { productOptions, onAddOption, onRemoveOption, onOptionChange, onOptionValueAdd, onOptionValueRemove } = useProductOptions({
+    localData,
+    setLocalData,
+    setHasChanges,
+    setVariantErrors,
+    t,
+  });
+
+  const {
+    variantGalleryOptions,
+    onVariantChange,
+    onVariantPriceChange,
+    onVariantGalleryChange,
+    onAddVariant,
+    onRemoveVariant,
+  } = useProductVariants({
+    localData,
+    setLocalData,
+    setHasChanges,
+    setVariantErrors,
+    defaultCurrency,
+    productOptions,
+    activeLang,
+    defaultLang,
+  });
 
   return {
     data: localData,
@@ -1611,6 +837,6 @@ export function useProductDetails() {
     onOptionValueRemove,
     variantErrors,
     variantGalleryOptions,
-    productOptions: localData?.options ?? [],
+    productOptions,
   };
 }

--- a/packages/plugin-commerce-dashboard/src/modules/products/hooks/use-product-details.ts
+++ b/packages/plugin-commerce-dashboard/src/modules/products/hooks/use-product-details.ts
@@ -81,13 +81,90 @@ const mapAssetIdsToSources = (
 
 const isLikelyExternalUrl = (value: string) => /^https?:\/\//i.test(value);
 
+const getUrlPath = (value: string): string | null => {
+  if (!value) return null;
+
+  try {
+    const url = new URL(value);
+    return url.pathname;
+  } catch (error) {
+    const normalized = value.split("?")[0];
+    return normalized.startsWith("/") ? normalized : null;
+  }
+};
+
+const findGalleryAssetIdByUrl = (
+  gallery: MediaSource[],
+  url: string
+): string | null => {
+  const targetPath = getUrlPath(url);
+  if (!targetPath) return null;
+
+  for (const entry of gallery) {
+    if (!entry) continue;
+
+    if (typeof entry === "string") {
+      if (!isLikelyExternalUrl(entry)) continue;
+      const entryPath = getUrlPath(entry);
+      if (entryPath && entryPath === targetPath) {
+        // String entries don't provide a stable asset identifier, so skip.
+        continue;
+      }
+      continue;
+    }
+
+    const urlsToCompare: string[] = [];
+    if (typeof entry.url === "string") {
+      urlsToCompare.push(entry.url);
+    }
+    const previewUrl = (entry as { previewUrl?: string | null }).previewUrl;
+    if (typeof previewUrl === "string") {
+      urlsToCompare.push(previewUrl);
+    }
+
+    for (const candidate of urlsToCompare) {
+      const candidatePath = getUrlPath(candidate);
+      if (candidatePath && candidatePath === targetPath) {
+        const assetId = extractAssetId(entry);
+        if (assetId) return assetId;
+      }
+    }
+
+    const entryPath = (entry as { path?: string | null }).path;
+    if (typeof entryPath === "string" && targetPath.endsWith(entryPath)) {
+      const assetId = extractAssetId(entry);
+      if (assetId) return assetId;
+    }
+  }
+
+  return null;
+};
+
+const normalizeThumbnailIdentifier = (
+  thumbnail: string | null | undefined,
+  gallery: MediaSource[]
+): string | null => {
+  if (!thumbnail) return null;
+  if (!isLikelyExternalUrl(thumbnail)) return thumbnail;
+
+  return findGalleryAssetIdByUrl(gallery, thumbnail);
+};
+
 const hydrateProductDetails = (
   product: ProductResponseDetailsModel
-): ProductDetailsState => ({
-  ...product,
-  gallery: product.gallery ?? [],
-  thumbnail: product.thumbnail ?? null,
-});
+): ProductDetailsState => {
+  const gallery = (product.gallery ?? []) as MediaSource[];
+  const normalizedThumbnail = normalizeThumbnailIdentifier(
+    product.thumbnail ?? null,
+    gallery
+  );
+
+  return {
+    ...product,
+    gallery,
+    thumbnail: normalizedThumbnail ?? product.thumbnail ?? null,
+  };
+};
 
 const findTranslationForUpsert = (
   product: ProductDetailsState,
@@ -516,6 +593,11 @@ export function useProductDetails() {
         }
       );
 
+      const thumbnailId = normalizeThumbnailIdentifier(
+        localData.thumbnail ?? null,
+        (localData.gallery ?? []) as MediaSource[]
+      );
+
       const body: ProductUpsertModel = {
         id: id && id !== "create" ? localData.id : undefined,
         language: activeLang,
@@ -531,7 +613,7 @@ export function useProductDetails() {
         expireAt: localData.expireAt,
         collections: localData.collections ?? null,
         gallery: galleryAssetIds,
-        thumbnail: localData.thumbnail ?? undefined,
+        thumbnail: thumbnailId ?? undefined,
         variants: normalizedVariants,
       };
 
@@ -653,13 +735,20 @@ export function useProductDetails() {
         ),
       }));
 
+      const nextGallerySources = mapAssetIdsToSources(
+        normalizedNextGallery,
+        localData.gallery ?? []
+      );
+
+      const normalizedThumbnailId = normalizeThumbnailIdentifier(
+        nextThumbnail,
+        nextGallerySources
+      );
+
       const updatedData: ProductDetailsState = {
         ...localData,
-        gallery: mapAssetIdsToSources(
-          normalizedNextGallery,
-          localData.gallery ?? []
-        ),
-        thumbnail: nextThumbnail,
+        gallery: nextGallerySources,
+        thumbnail: normalizedThumbnailId ?? nextThumbnail,
         variants: sanitizedVariants,
       };
 
@@ -707,7 +796,7 @@ export function useProductDetails() {
         expireAt: updatedData.expireAt,
         collections: updatedData.collections ?? [],
         gallery: normalizedNextGallery,
-        thumbnail: nextThumbnail ?? undefined,
+        thumbnail: normalizedThumbnailId ?? undefined,
       };
 
       try {

--- a/packages/plugin-commerce-dashboard/src/modules/products/hooks/use-product-details.ts
+++ b/packages/plugin-commerce-dashboard/src/modules/products/hooks/use-product-details.ts
@@ -13,8 +13,13 @@ import type {
   ProductUpsertModel,
   ProductSeoModel,
   ProductPriceModel,
+  ProductVariantModel,
 } from "@kitejs-cms/plugin-commerce-api";
 import type { MediaSource } from "./use-product-media";
+import type {
+  VariantFieldErrors,
+  VariantGalleryOption,
+} from "../components/variants-section";
 
 const arraysEqual = (a: string[], b: string[]) =>
   a.length === b.length && a.every((value, index) => value === b[index]);
@@ -73,6 +78,8 @@ const mapAssetIdsToSources = (
 
   return assetIds.map((id) => lookup.get(id) ?? id);
 };
+
+const isLikelyExternalUrl = (value: string) => /^https?:\/\//i.test(value);
 
 const hydrateProductDetails = (
   product: ProductResponseDetailsModel
@@ -145,6 +152,7 @@ export function useProductDetails() {
   const [showUnsavedAlert, setShowUnsavedAlert] = useState(false);
 
   const [localData, setLocalData] = useState<ProductDetailsState | null>(null);
+  const [variantErrors, setVariantErrors] = useState<VariantFieldErrors[]>([]);
 
   useEffect(() => {
     const items = [
@@ -194,6 +202,7 @@ export function useProductDetails() {
 
       setLocalData(newProduct);
       setActiveLang(defaultLang);
+      setVariantErrors([]);
       return;
     }
 
@@ -203,6 +212,7 @@ export function useProductDetails() {
         if (result?.data) {
           setLocalData(hydrateProductDetails(result.data));
           setHasChanges(false);
+          setVariantErrors([]);
         }
       })();
     }
@@ -385,8 +395,39 @@ export function useProductDetails() {
       errors.slug = t("products.errors.slugRequired", "Slug is required");
     }
 
+    const variants = localData.variants ?? [];
+    let hasVariantValidationErrors = false;
+    const nextVariantErrors: VariantFieldErrors[] = variants.map(() => ({}));
+
+    variants.forEach((variant, index) => {
+      const variantError: VariantFieldErrors = {};
+      if (!variant.title?.trim()) {
+        variantError.title = t(
+          "products.errors.variantTitleRequired",
+          "Variant name is required"
+        );
+      }
+      if (!variant.sku?.trim()) {
+        variantError.sku = t(
+          "products.errors.variantSkuRequired",
+          "Variant SKU is required"
+        );
+      }
+
+      if (Object.keys(variantError).length > 0) {
+        hasVariantValidationErrors = true;
+        nextVariantErrors[index] = variantError;
+      }
+    });
+
+    if (hasVariantValidationErrors) {
+      setVariantErrors(nextVariantErrors);
+    } else {
+      setVariantErrors([]);
+    }
+
     setFormErrors(errors);
-    return Object.keys(errors).length === 0;
+    return Object.keys(errors).length === 0 && !hasVariantValidationErrors;
   }, [localData, activeLang, t]);
 
   const handleSave = useCallback(async () => {
@@ -418,19 +459,47 @@ export function useProductDetails() {
         .map((entry) => extractAssetId(entry))
         .filter((id): id is string => Boolean(id));
 
-      const normalizedVariants = (localData.variants ?? []).map((variant) => ({
-        id: variant.id,
-        title: variant.title,
-        sku: variant.sku,
-        barcode: variant.barcode,
-        inventoryQuantity: variant.inventoryQuantity,
-        allowBackorder: variant.allowBackorder,
-        prices: (variant.prices ?? []).map((price) => ({
-          currencyCode: price.currencyCode,
-          amount: price.amount,
-          compareAtAmount: price.compareAtAmount,
-        })),
-      }));
+      const normalizedVariants = (localData.variants ?? []).map(
+        (variant, variantIndex) => {
+          const normalizedPrices = (variant.prices ?? []).map((price) => ({
+            currencyCode: price.currencyCode ?? defaultCurrency,
+            amount:
+              typeof price.amount === "number" && !Number.isNaN(price.amount)
+                ? price.amount
+                : 0,
+            compareAtAmount:
+              typeof price.compareAtAmount === "number" &&
+              !Number.isNaN(price.compareAtAmount)
+                ? price.compareAtAmount
+                : undefined,
+          }));
+
+          const gallery = (variant.gallery ?? []).filter(
+            (id): id is string => typeof id === "string" && Boolean(id)
+          );
+
+          const optionName = variant.optionName?.trim() || "default";
+          const optionValue =
+            variant.optionValue?.trim() || `${optionName}-${variantIndex + 1}`;
+
+          return {
+            id: variant.id,
+            title: variant.title ?? "",
+            sku: variant.sku ?? "",
+            barcode: variant.barcode,
+            inventoryQuantity:
+              typeof variant.inventoryQuantity === "number"
+                ? Math.max(0, Math.trunc(variant.inventoryQuantity))
+                : undefined,
+            allowBackorder: Boolean(variant.allowBackorder),
+            prices: normalizedPrices,
+            gallery,
+            downloadUrl: variant.downloadUrl,
+            optionName,
+            optionValue,
+          } satisfies ProductVariantModel;
+        }
+      );
 
       const body: ProductUpsertModel = {
         id: id && id !== "create" ? localData.id : undefined,
@@ -471,6 +540,7 @@ export function useProductDetails() {
         setLocalData(hydrateProductDetails(result.data));
         setHasChanges(false);
         setFormErrors({});
+        setVariantErrors([]);
 
         if (id === "create") {
           navigate(`/commerce/products/${result.data.id}`);
@@ -497,7 +567,16 @@ export function useProductDetails() {
         ),
       });
     }
-  }, [localData, activeLang, id, fetchData, navigate, t, validateForm]);
+  }, [
+    localData,
+    activeLang,
+    id,
+    fetchData,
+    navigate,
+    t,
+    validateForm,
+    defaultCurrency,
+  ]);
 
   const onSeoChange = useCallback(
     <K extends keyof ProductSeoModel>(
@@ -551,6 +630,14 @@ export function useProductDetails() {
         return;
       }
 
+      const allowedGalleryIds = new Set(normalizedNextGallery);
+      const sanitizedVariants = (localData.variants ?? []).map((variant) => ({
+        ...variant,
+        gallery: (variant.gallery ?? []).filter((assetId): assetId is string =>
+          typeof assetId === "string" && allowedGalleryIds.has(assetId)
+        ),
+      }));
+
       const updatedData: ProductDetailsState = {
         ...localData,
         gallery: mapAssetIdsToSources(
@@ -558,6 +645,7 @@ export function useProductDetails() {
           localData.gallery ?? []
         ),
         thumbnail: nextThumbnail,
+        variants: sanitizedVariants,
       };
 
       setLocalData(updatedData);
@@ -671,6 +759,28 @@ export function useProductDetails() {
         variants[index] = updated;
         return { ...prev, variants };
       });
+      setVariantErrors((prev) => {
+        if (!prev.length) return prev;
+        const current = prev[index];
+        if (!current) return prev;
+        if (
+          field !== "title" &&
+          field !== "sku" &&
+          field !== "inventoryQuantity"
+        ) {
+          return prev;
+        }
+
+        if (!current[field]) {
+          return prev;
+        }
+
+        const next = [...prev];
+        const updatedErrors = { ...current } as VariantFieldErrors;
+        delete updatedErrors[field];
+        next[index] = Object.keys(updatedErrors).length ? updatedErrors : {};
+        return next;
+      });
       setHasChanges(true);
     },
     []
@@ -719,7 +829,40 @@ export function useProductDetails() {
     [defaultCurrency]
   );
 
+  const onVariantGalleryChange = useCallback(
+    (index: number, gallery: string[]) => {
+      setLocalData((prev) => {
+        if (!prev) return prev;
+        const variants = [...(prev.variants ?? [])];
+        const current = variants[index];
+        if (!current) return prev;
+
+        variants[index] = {
+          ...current,
+          gallery,
+        };
+
+        return { ...prev, variants };
+      });
+
+      setVariantErrors((prev) => {
+        if (!prev.length) return prev;
+        const current = prev[index];
+        if (!current?.gallery) return prev;
+        const next = [...prev];
+        const updated = { ...current } as VariantFieldErrors;
+        delete updated.gallery;
+        next[index] = Object.keys(updated).length ? updated : {};
+        return next;
+      });
+
+      setHasChanges(true);
+    },
+    []
+  );
+
   const onAddVariant = useCallback(() => {
+    let didAdd = false;
     setLocalData((prev) => {
       if (!prev) return prev;
 
@@ -741,24 +884,81 @@ export function useProductDetails() {
         optionValue: `default-${Date.now()}`,
       } as ProductDetailsState["variants"][number];
 
+      didAdd = true;
+
       return {
         ...prev,
         variants: [...(prev.variants ?? []), variant],
       };
     });
+    if (didAdd) {
+      setVariantErrors((prev) => [...prev, {}]);
+    }
     setHasChanges(true);
   }, [defaultCurrency]);
 
   const onRemoveVariant = useCallback((index: number) => {
+    let didRemove = false;
     setLocalData((prev) => {
       if (!prev) return prev;
       const variants = [...(prev.variants ?? [])];
       if (!variants[index]) return prev;
       variants.splice(index, 1);
+      didRemove = true;
       return { ...prev, variants };
     });
+    if (didRemove) {
+      setVariantErrors((prev) => {
+        if (!prev.length) return prev;
+        const next = [...prev];
+        next.splice(index, 1);
+        return next;
+      });
+    }
     setHasChanges(true);
   }, []);
+
+  const variantGalleryOptions = useMemo<VariantGalleryOption[]>(() => {
+    if (!localData) return [];
+
+    const languages = [activeLang, defaultLang].filter(
+      (lang): lang is string => Boolean(lang)
+    );
+
+    return (localData.gallery ?? [])
+      .map((entry) => {
+        const assetId = extractAssetId(entry);
+        if (!assetId) return null;
+
+        if (typeof entry === "string") {
+          return {
+            id: assetId,
+            label: assetId,
+            url: isLikelyExternalUrl(entry) ? entry : null,
+          } satisfies VariantGalleryOption;
+        }
+
+        const localizedLabel = languages.reduce<string | undefined>(
+          (acc, lang) => {
+            if (acc) return acc;
+            const title = entry.title?.[lang]?.trim();
+            if (title) return title;
+            const alt = entry.alt?.[lang]?.trim();
+            if (alt) return alt;
+            return acc;
+          },
+          undefined
+        );
+
+        return {
+          id: assetId,
+          label:
+            localizedLabel ?? entry.name ?? entry.path ?? assetId ?? "",
+          url: entry.url ?? null,
+        } satisfies VariantGalleryOption;
+      })
+      .filter((option): option is VariantGalleryOption => option !== null);
+  }, [localData, activeLang, defaultLang]);
 
   return {
     data: localData,
@@ -781,7 +981,10 @@ export function useProductDetails() {
     defaultCurrency,
     onVariantChange,
     onVariantPriceChange,
+    onVariantGalleryChange,
     onAddVariant,
     onRemoveVariant,
+    variantErrors,
+    variantGalleryOptions,
   };
 }

--- a/packages/plugin-commerce-dashboard/src/modules/products/hooks/use-product-details.ts
+++ b/packages/plugin-commerce-dashboard/src/modules/products/hooks/use-product-details.ts
@@ -12,6 +12,7 @@ import type {
   ProductTranslationModel,
   ProductUpsertModel,
   ProductSeoModel,
+  ProductPriceModel,
 } from "@kitejs-cms/plugin-commerce-api";
 import type { MediaSource } from "./use-product-media";
 
@@ -119,6 +120,20 @@ export function useProductDetails() {
     () => cmsSettings?.defaultLanguage,
     [cmsSettings]
   );
+
+  const defaultCurrency = useMemo(() => {
+    if (!cmsSettings) return "EUR";
+    const commerceSettings = (cmsSettings as unknown as {
+      commerce?: { defaultCurrency?: string };
+    })?.commerce;
+
+    const code = commerceSettings?.defaultCurrency;
+    if (typeof code === "string" && code.trim()) {
+      return code.trim().toUpperCase();
+    }
+
+    return "EUR";
+  }, [cmsSettings]);
 
   const { loading, fetchData } = useApi<ProductResponseDetailsModel>();
   const { id } = useParams<{ id: string }>();
@@ -403,6 +418,20 @@ export function useProductDetails() {
         .map((entry) => extractAssetId(entry))
         .filter((id): id is string => Boolean(id));
 
+      const normalizedVariants = (localData.variants ?? []).map((variant) => ({
+        id: variant.id,
+        title: variant.title,
+        sku: variant.sku,
+        barcode: variant.barcode,
+        inventoryQuantity: variant.inventoryQuantity,
+        allowBackorder: variant.allowBackorder,
+        prices: (variant.prices ?? []).map((price) => ({
+          currencyCode: price.currencyCode,
+          amount: price.amount,
+          compareAtAmount: price.compareAtAmount,
+        })),
+      }));
+
       const body: ProductUpsertModel = {
         id: id && id !== "create" ? localData.id : undefined,
         language: activeLang,
@@ -419,6 +448,7 @@ export function useProductDetails() {
         collections: localData.collections ?? null,
         gallery: galleryAssetIds,
         thumbnail: localData.thumbnail ?? undefined,
+        variants: normalizedVariants,
       };
 
       const result = await fetchData("commerce/products", "POST", body);
@@ -594,6 +624,142 @@ export function useProductDetails() {
     [activeLang, defaultLang, fetchData, localData, t]
   );
 
+  const onVariantChange = useCallback(
+    (
+      index: number,
+      field:
+        | "title"
+        | "sku"
+        | "barcode"
+        | "inventoryQuantity"
+        | "allowBackorder",
+      value: string | number | boolean | undefined
+    ) => {
+      setLocalData((prev) => {
+        if (!prev) return prev;
+        const variants = [...(prev.variants ?? [])];
+        const current = variants[index];
+        if (!current) return prev;
+
+        const updated = { ...current } as typeof current;
+
+        switch (field) {
+          case "title":
+          case "sku":
+          case "barcode":
+            updated[field] = (value as string) ?? "";
+            break;
+          case "inventoryQuantity": {
+            const numericValue =
+              typeof value === "number"
+                ? value
+                : value === undefined
+                  ? undefined
+                  : Number(value);
+
+            updated.inventoryQuantity =
+              numericValue === undefined || Number.isNaN(numericValue)
+                ? 0
+                : Math.max(0, Math.trunc(numericValue));
+            break;
+          }
+          case "allowBackorder":
+            updated.allowBackorder = Boolean(value);
+            break;
+        }
+
+        variants[index] = updated;
+        return { ...prev, variants };
+      });
+      setHasChanges(true);
+    },
+    []
+  );
+
+  const onVariantPriceChange = useCallback(
+    (index: number, field: keyof ProductPriceModel, value: string) => {
+      setLocalData((prev) => {
+        if (!prev) return prev;
+        const variants = [...(prev.variants ?? [])];
+        const current = variants[index];
+        if (!current) return prev;
+
+        const prices = [...(current.prices ?? [])];
+        const primary = {
+          currencyCode: defaultCurrency,
+          amount: 0,
+          compareAtAmount: undefined as number | undefined,
+          ...prices[0],
+        };
+
+        if (field === "currencyCode") {
+          primary.currencyCode = value
+            ? value.trim().toUpperCase().slice(0, 3)
+            : defaultCurrency;
+        }
+
+        if (field === "amount") {
+          const parsed = Number.parseFloat(value);
+          primary.amount = Number.isNaN(parsed) ? 0 : Math.max(0, parsed);
+        }
+
+        if (field === "compareAtAmount") {
+          const parsed = Number.parseFloat(value);
+          primary.compareAtAmount = Number.isNaN(parsed)
+            ? undefined
+            : Math.max(0, parsed);
+        }
+
+        prices[0] = primary;
+        variants[index] = { ...current, prices };
+        return { ...prev, variants };
+      });
+      setHasChanges(true);
+    },
+    [defaultCurrency]
+  );
+
+  const onAddVariant = useCallback(() => {
+    setLocalData((prev) => {
+      if (!prev) return prev;
+
+      const variant: ProductDetailsState["variants"][number] = {
+        id: undefined,
+        title: "",
+        sku: "",
+        barcode: "",
+        prices: [
+          {
+            currencyCode: defaultCurrency,
+            amount: 0,
+          },
+        ],
+        inventoryQuantity: 0,
+        allowBackorder: false,
+        gallery: [],
+        optionName: "default",
+        optionValue: `default-${Date.now()}`,
+      } as ProductDetailsState["variants"][number];
+
+      return {
+        ...prev,
+        variants: [...(prev.variants ?? []), variant],
+      };
+    });
+    setHasChanges(true);
+  }, [defaultCurrency]);
+
+  const onRemoveVariant = useCallback((index: number) => {
+    setLocalData((prev) => {
+      if (!prev) return prev;
+      const variants = [...(prev.variants ?? [])];
+      if (!variants[index]) return prev;
+      variants.splice(index, 1);
+      return { ...prev, variants };
+    });
+    setHasChanges(true);
+  }, []);
+
   return {
     data: localData,
     loading,
@@ -612,5 +778,10 @@ export function useProductDetails() {
     showUnsavedAlert,
     formErrors,
     t,
+    defaultCurrency,
+    onVariantChange,
+    onVariantPriceChange,
+    onAddVariant,
+    onRemoveVariant,
   };
 }

--- a/packages/plugin-commerce-dashboard/src/modules/products/hooks/use-product-options.ts
+++ b/packages/plugin-commerce-dashboard/src/modules/products/hooks/use-product-options.ts
@@ -1,0 +1,357 @@
+import { useCallback } from "react";
+import type { VariantFieldErrors } from "../components/variants-section";
+import type { ProductDetailsState } from "./product-details.types";
+import { slugifyOptionHandle } from "./product-details.utils";
+import type { TFunction } from "react-i18next";
+
+export function useProductOptions({
+  localData,
+  setLocalData,
+  setHasChanges,
+  setVariantErrors,
+  t,
+}: {
+  localData: ProductDetailsState | null;
+  setLocalData: React.Dispatch<
+    React.SetStateAction<ProductDetailsState | null>
+  >;
+  setHasChanges: (value: boolean) => void;
+  setVariantErrors: React.Dispatch<
+    React.SetStateAction<VariantFieldErrors[]>
+  >;
+  t: TFunction<"commerce">;
+}) {
+  const onAddOption = useCallback(() => {
+    setLocalData((prev) => {
+      if (!prev) return prev;
+
+      const existingOptions = prev.options ?? [];
+      const position = existingOptions.length;
+      const defaultLabel = t("products.details.options.defaultName", {
+        index: position + 1,
+      });
+      const baseHandle = slugifyOptionHandle(defaultLabel) || `option-${position + 1}`;
+
+      let handle = baseHandle;
+      let attempt = 1;
+      const existingHandles = new Set(existingOptions.map((option) => option.name));
+      while (existingHandles.has(handle)) {
+        handle = `${baseHandle}-${++attempt}`;
+      }
+
+      const option: ProductDetailsState["options"][number] = {
+        name: handle,
+        displayName: defaultLabel,
+        values: [],
+        position,
+      };
+
+      return {
+        ...prev,
+        options: [...existingOptions, option],
+      };
+    });
+    setHasChanges(true);
+  }, [setHasChanges, setLocalData, t]);
+
+  const onRemoveOption = useCallback(
+    (index: number) => {
+      const clearedIndexes = new Set<number>();
+      const missingOptionIndexes = new Set<number>();
+      const missingValueIndexes = new Set<number>();
+
+      setLocalData((prev) => {
+        if (!prev) return prev;
+        const options = [...(prev.options ?? [])];
+        const target = options[index];
+        if (!target) return prev;
+
+        options.splice(index, 1);
+
+        const normalizedOptions = options.map((option, optionIndex) => ({
+          ...option,
+          position: optionIndex,
+        }));
+
+        const fallbackOption = normalizedOptions[0];
+
+        const variants = (prev.variants ?? []).map((variant, variantIndex) => {
+          if (variant.optionName === target.name) {
+            if (fallbackOption?.name) {
+              const hasExistingValue = fallbackOption.values?.includes(
+                variant.optionValue ?? ""
+              );
+              const fallbackValue = hasExistingValue
+                ? variant.optionValue
+                : fallbackOption.values?.[0];
+
+              if (fallbackValue) {
+                clearedIndexes.add(variantIndex);
+              } else {
+                missingValueIndexes.add(variantIndex);
+              }
+
+              return {
+                ...variant,
+                optionName: fallbackOption.name,
+                optionValue: fallbackValue,
+              };
+            }
+
+            missingOptionIndexes.add(variantIndex);
+            missingValueIndexes.add(variantIndex);
+            return {
+              ...variant,
+              optionName: undefined,
+              optionValue: undefined,
+            };
+          }
+
+          return variant;
+        });
+
+        return {
+          ...prev,
+          options: normalizedOptions,
+          variants,
+        };
+      });
+
+      if (
+        clearedIndexes.size ||
+        missingOptionIndexes.size ||
+        missingValueIndexes.size
+      ) {
+        setVariantErrors((prev) => {
+          const next = [...prev];
+          clearedIndexes.forEach((idx) => {
+            while (next.length <= idx) {
+              next.push({});
+            }
+            const current = next[idx];
+            if (!current) return;
+            const updated = { ...current } as VariantFieldErrors;
+            delete updated.optionName;
+            delete updated.optionValue;
+            next[idx] = Object.keys(updated).length ? updated : {};
+          });
+
+          missingOptionIndexes.forEach((idx) => {
+            while (next.length <= idx) {
+              next.push({});
+            }
+            const current = next[idx] ?? {};
+            next[idx] = {
+              ...current,
+              optionName: t(
+                "products.errors.variantOptionRequired",
+                "Select an option"
+              ),
+              optionValue: t(
+                "products.errors.variantOptionValueRequired",
+                "Select a value"
+              ),
+            };
+          });
+
+          missingValueIndexes.forEach((idx) => {
+            while (next.length <= idx) {
+              next.push({});
+            }
+            if (missingOptionIndexes.has(idx)) return;
+            const current = next[idx] ?? {};
+            next[idx] = {
+              ...current,
+              optionValue: t(
+                "products.errors.variantOptionValueRequired",
+                "Select a value"
+              ),
+            };
+          });
+
+          return next;
+        });
+      }
+
+      setHasChanges(true);
+    },
+    [setHasChanges, setLocalData, setVariantErrors, t]
+  );
+
+  const onOptionChange = useCallback(
+    (
+      index: number,
+      field: "name" | "displayName",
+      value: string
+    ) => {
+      setLocalData((prev) => {
+        if (!prev) return prev;
+        const options = [...(prev.options ?? [])];
+        const target = options[index];
+        if (!target) return prev;
+
+        const updatedOption = { ...target } as ProductDetailsState["options"][number];
+        if (field === "displayName") {
+          updatedOption.displayName = value;
+          const currentSlug = slugifyOptionHandle(target.displayName ?? "");
+          const currentHandle = target.name ?? "";
+          const nextSlug = slugifyOptionHandle(value);
+
+          if (!currentHandle || currentHandle === currentSlug) {
+            updatedOption.name = nextSlug || currentHandle;
+          }
+        } else {
+          const nextHandle = slugifyOptionHandle(value);
+          updatedOption.name = nextHandle;
+
+          const variants = (prev.variants ?? []).map((variant) => {
+            if (variant.optionName === target.name) {
+              return {
+                ...variant,
+                optionName: nextHandle,
+              };
+            }
+            return variant;
+          });
+
+          options[index] = {
+            ...updatedOption,
+            position: target.position,
+          };
+
+          return {
+            ...prev,
+            options,
+            variants,
+          };
+        }
+
+        options[index] = {
+          ...updatedOption,
+          position: target.position,
+        };
+
+        return {
+          ...prev,
+          options,
+        };
+      });
+
+      setHasChanges(true);
+    },
+    [setHasChanges, setLocalData]
+  );
+
+  const onOptionValueAdd = useCallback(
+    (index: number, value: string) => {
+      setLocalData((prev) => {
+        if (!prev) return prev;
+        const options = [...(prev.options ?? [])];
+        const target = options[index];
+        if (!target) return prev;
+
+        const trimmedValue = value.trim();
+        if (!trimmedValue) return prev;
+
+        const existingValues = new Set(target.values ?? []);
+        if (existingValues.has(trimmedValue)) {
+          return prev;
+        }
+
+        const nextValues = [...(target.values ?? []), trimmedValue];
+
+        options[index] = {
+          ...target,
+          values: nextValues,
+        };
+
+        return {
+          ...prev,
+          options,
+        };
+      });
+
+      setHasChanges(true);
+    },
+    [setHasChanges, setLocalData]
+  );
+
+  const onOptionValueRemove = useCallback(
+    (index: number, value: string) => {
+      const missingValueIndexes = new Set<number>();
+
+      setLocalData((prev) => {
+        if (!prev) return prev;
+        const options = [...(prev.options ?? [])];
+        const target = options[index];
+        if (!target) return prev;
+
+        const filteredValues = (target.values ?? []).filter(
+          (entry) => entry !== value
+        );
+
+        options[index] = {
+          ...target,
+          values: filteredValues,
+        };
+
+        const variants = (prev.variants ?? []).map((variant, variantIndex) => {
+          if (variant.optionName === target.name && variant.optionValue === value) {
+            const fallbackValue = filteredValues[0];
+            if (fallbackValue) {
+              return {
+                ...variant,
+                optionValue: fallbackValue,
+              };
+            }
+            missingValueIndexes.add(variantIndex);
+            return {
+              ...variant,
+              optionValue: undefined,
+            };
+          }
+          return variant;
+        });
+
+        return {
+          ...prev,
+          options,
+          variants,
+        };
+      });
+
+      if (missingValueIndexes.size) {
+        setVariantErrors((prev) => {
+          const next = [...prev];
+          missingValueIndexes.forEach((idx) => {
+            while (next.length <= idx) {
+              next.push({});
+            }
+            const current = next[idx] ?? {};
+            next[idx] = {
+              ...current,
+              optionValue: t(
+                "products.errors.variantOptionValueRequired",
+                "Select a value"
+              ),
+            };
+          });
+
+          return next;
+        });
+      }
+
+      setHasChanges(true);
+    },
+    [setHasChanges, setLocalData, setVariantErrors, t]
+  );
+
+  return {
+    productOptions: localData?.options ?? [],
+    onAddOption,
+    onRemoveOption,
+    onOptionChange,
+    onOptionValueAdd,
+    onOptionValueRemove,
+  };
+}

--- a/packages/plugin-commerce-dashboard/src/modules/products/hooks/use-product-options.ts
+++ b/packages/plugin-commerce-dashboard/src/modules/products/hooks/use-product-options.ts
@@ -1,6 +1,6 @@
 import { useCallback } from "react";
 import type { VariantFieldErrors } from "../components/variants-section";
-import type { TFunction } from "i18next";
+import type { TFunction } from "react-i18next";
 import type { ProductDetailsState } from "./product-details.types";
 import { slugifyOptionHandle } from "./product-details.utils";
 

--- a/packages/plugin-commerce-dashboard/src/modules/products/hooks/use-product-options.ts
+++ b/packages/plugin-commerce-dashboard/src/modules/products/hooks/use-product-options.ts
@@ -1,6 +1,6 @@
 import { useCallback } from "react";
+import { useTranslation } from "react-i18next";
 import type { VariantFieldErrors } from "../components/variants-section";
-import type { TFunction } from "react-i18next";
 import type { ProductDetailsState } from "./product-details.types";
 import { slugifyOptionHandle } from "./product-details.utils";
 
@@ -9,7 +9,6 @@ export function useProductOptions({
   setLocalData,
   setHasChanges,
   setVariantErrors,
-  t,
 }: {
   localData: ProductDetailsState | null;
   setLocalData: React.Dispatch<
@@ -19,8 +18,9 @@ export function useProductOptions({
   setVariantErrors: React.Dispatch<
     React.SetStateAction<VariantFieldErrors[]>
   >;
-  t: TFunction<"commerce">;
 }) {
+  const { t } = useTranslation<"commerce">("commerce");
+
   const onAddOption = useCallback(() => {
     setLocalData((prev) => {
       if (!prev) return prev;

--- a/packages/plugin-commerce-dashboard/src/modules/products/hooks/use-product-options.ts
+++ b/packages/plugin-commerce-dashboard/src/modules/products/hooks/use-product-options.ts
@@ -1,8 +1,8 @@
 import { useCallback } from "react";
 import type { VariantFieldErrors } from "../components/variants-section";
+import type { TFunction } from "i18next";
 import type { ProductDetailsState } from "./product-details.types";
 import { slugifyOptionHandle } from "./product-details.utils";
-import type { TFunction } from "react-i18next";
 
 export function useProductOptions({
   localData,

--- a/packages/plugin-commerce-dashboard/src/modules/products/hooks/use-product-variants.ts
+++ b/packages/plugin-commerce-dashboard/src/modules/products/hooks/use-product-variants.ts
@@ -1,0 +1,289 @@
+import { useCallback, useMemo } from "react";
+import type { ProductPriceModel } from "@kitejs-cms/plugin-commerce-api";
+import type { VariantFieldErrors, VariantGalleryOption } from "../components/variants-section";
+import { buildVariantGalleryOptions, slugifyOptionHandle } from "./product-details.utils";
+import type { ProductDetailsState } from "./product-details.types";
+
+export function useProductVariants({
+  localData,
+  setLocalData,
+  setHasChanges,
+  setVariantErrors,
+  defaultCurrency,
+  productOptions,
+  activeLang,
+  defaultLang,
+}: {
+  localData: ProductDetailsState | null;
+  setLocalData: React.Dispatch<
+    React.SetStateAction<ProductDetailsState | null>
+  >;
+  setHasChanges: (value: boolean) => void;
+  setVariantErrors: React.Dispatch<
+    React.SetStateAction<VariantFieldErrors[]>
+  >;
+  defaultCurrency: string;
+  productOptions: ProductDetailsState["options"];
+  activeLang: string;
+  defaultLang?: string;
+}) {
+  const onVariantChange = useCallback(
+    (
+      index: number,
+      field:
+        | "title"
+        | "sku"
+        | "barcode"
+        | "inventoryQuantity"
+        | "allowBackorder"
+        | "optionName"
+        | "optionValue",
+      value: string | number | boolean | undefined
+    ) => {
+      setLocalData((prev) => {
+        if (!prev) return prev;
+        const variants = [...(prev.variants ?? [])];
+        const current = variants[index];
+        if (!current) return prev;
+
+        const updated = { ...current } as typeof current;
+
+        switch (field) {
+          case "title":
+          case "sku":
+          case "barcode":
+            updated[field] = (value as string) ?? "";
+            break;
+          case "inventoryQuantity": {
+            const numericValue =
+              typeof value === "number"
+                ? value
+                : value === undefined
+                  ? undefined
+                  : Number(value);
+
+            updated.inventoryQuantity =
+              numericValue === undefined || Number.isNaN(numericValue)
+                ? 0
+                : Math.max(0, Math.trunc(numericValue));
+            break;
+          }
+          case "allowBackorder":
+            updated.allowBackorder = Boolean(value);
+            break;
+          case "optionName": {
+            const rawValue = typeof value === "string" ? value : "";
+            const normalizedValue = rawValue ? slugifyOptionHandle(rawValue) : "";
+            const matchedOption = productOptions.find(
+              (option) => option.name === rawValue || option.name === normalizedValue
+            );
+
+            if (matchedOption) {
+              updated.optionName = matchedOption.name;
+              if (
+                matchedOption.values?.length &&
+                matchedOption.values.includes(updated.optionValue ?? "")
+              ) {
+                updated.optionValue = updated.optionValue;
+              } else {
+                updated.optionValue = matchedOption.values?.[0];
+              }
+            } else {
+              updated.optionName =
+                normalizedValue && normalizedValue.length > 0
+                  ? normalizedValue
+                  : undefined;
+            }
+            break;
+          }
+          case "optionValue": {
+            if (typeof value === "string") {
+              const trimmed = value.trim();
+              updated.optionValue = trimmed.length > 0 ? trimmed : undefined;
+            } else {
+              updated.optionValue = undefined;
+            }
+            break;
+          }
+        }
+
+        variants[index] = updated;
+        return { ...prev, variants };
+      });
+      setVariantErrors((prev) => {
+        if (!prev.length) return prev;
+        const current = prev[index];
+        if (!current) return prev;
+        const fieldKey = field as keyof VariantFieldErrors;
+        if (!current[fieldKey]) {
+          return prev;
+        }
+
+        const next = [...prev];
+        const updatedErrors = { ...current } as VariantFieldErrors;
+        delete updatedErrors[fieldKey];
+        next[index] = Object.keys(updatedErrors).length ? updatedErrors : {};
+        return next;
+      });
+      setHasChanges(true);
+    },
+    [productOptions, setHasChanges, setLocalData, setVariantErrors]
+  );
+
+  const onVariantPriceChange = useCallback(
+    (index: number, field: keyof ProductPriceModel, value: string) => {
+      setLocalData((prev) => {
+        if (!prev) return prev;
+        const variants = [...(prev.variants ?? [])];
+        const current = variants[index];
+        if (!current) return prev;
+
+        const prices = [...(current.prices ?? [])];
+        const primary = {
+          currencyCode: defaultCurrency,
+          amount: 0,
+          compareAtAmount: undefined as number | undefined,
+          ...prices[0],
+        };
+
+        if (field === "currencyCode") {
+          primary.currencyCode = value
+            ? value.trim().toUpperCase().slice(0, 3)
+            : defaultCurrency;
+        }
+
+        if (field === "amount") {
+          const parsed = Number.parseFloat(value);
+          primary.amount = Number.isNaN(parsed) ? 0 : Math.max(0, parsed);
+        }
+
+        if (field === "compareAtAmount") {
+          const parsed = Number.parseFloat(value);
+          primary.compareAtAmount = Number.isNaN(parsed)
+            ? undefined
+            : Math.max(0, parsed);
+        }
+
+        prices[0] = primary;
+        variants[index] = { ...current, prices };
+        return { ...prev, variants };
+      });
+      setHasChanges(true);
+    },
+    [defaultCurrency, setHasChanges, setLocalData]
+  );
+
+  const onVariantGalleryChange = useCallback(
+    (index: number, gallery: string[]) => {
+      setLocalData((prev) => {
+        if (!prev) return prev;
+        const variants = [...(prev.variants ?? [])];
+        const current = variants[index];
+        if (!current) return prev;
+
+        variants[index] = {
+          ...current,
+          gallery,
+        };
+
+        return { ...prev, variants };
+      });
+
+      setVariantErrors((prev) => {
+        if (!prev.length) return prev;
+        const current = prev[index];
+        if (!current?.gallery) return prev;
+        const next = [...prev];
+        const updated = { ...current } as VariantFieldErrors;
+        delete updated.gallery;
+        next[index] = Object.keys(updated).length ? updated : {};
+        return next;
+      });
+
+      setHasChanges(true);
+    },
+    [setHasChanges, setLocalData, setVariantErrors]
+  );
+
+  const onAddVariant = useCallback(() => {
+    let didAdd = false;
+    setLocalData((prev) => {
+      if (!prev) return prev;
+
+      const primaryOption = prev.options?.[0];
+      const optionHandle = primaryOption?.name?.trim() || "default";
+      const initialOptionValue =
+        primaryOption?.values?.[0] ?? `${optionHandle}-${Date.now()}`;
+
+      const variant: ProductDetailsState["variants"][number] = {
+        id: undefined,
+        title: "",
+        sku: "",
+        barcode: "",
+        prices: [
+          {
+            currencyCode: defaultCurrency,
+            amount: 0,
+          },
+        ],
+        inventoryQuantity: 0,
+        allowBackorder: false,
+        gallery: [],
+        optionName: optionHandle,
+        optionValue: initialOptionValue,
+      } as ProductDetailsState["variants"][number];
+
+      didAdd = true;
+
+      return {
+        ...prev,
+        variants: [...(prev.variants ?? []), variant],
+      };
+    });
+    if (didAdd) {
+      setVariantErrors((prev) => [...prev, {}]);
+    }
+    setHasChanges(true);
+  }, [defaultCurrency, setHasChanges, setLocalData, setVariantErrors]);
+
+  const onRemoveVariant = useCallback(
+    (index: number) => {
+      let didRemove = false;
+      setLocalData((prev) => {
+        if (!prev) return prev;
+        const variants = [...(prev.variants ?? [])];
+        if (!variants[index]) return prev;
+        variants.splice(index, 1);
+        didRemove = true;
+        return { ...prev, variants };
+      });
+      if (didRemove) {
+        setVariantErrors((prev) => {
+          if (!prev.length) return prev;
+          const next = [...prev];
+          next.splice(index, 1);
+          return next;
+        });
+      }
+      setHasChanges(true);
+    },
+    [setHasChanges, setLocalData, setVariantErrors]
+  );
+
+  const variantGalleryOptions = useMemo<VariantGalleryOption[]>(() => {
+    const languages = [activeLang, defaultLang].filter(
+      (lang): lang is string => Boolean(lang)
+    );
+
+    return buildVariantGalleryOptions(localData, languages, localData?.gallery ?? []);
+  }, [activeLang, defaultLang, localData]);
+
+  return {
+    variantGalleryOptions,
+    onVariantChange,
+    onVariantPriceChange,
+    onVariantGalleryChange,
+    onAddVariant,
+    onRemoveVariant,
+  };
+}

--- a/packages/plugin-commerce-dashboard/src/modules/products/pages/product-details.tsx
+++ b/packages/plugin-commerce-dashboard/src/modules/products/pages/product-details.tsx
@@ -10,6 +10,10 @@ import { SeoSection } from "../components/seo-section";
 import { UnsavedChangesDialog } from "../../collections/components/unsaved-changes-dialog";
 import { SettingsSection } from "../components/settings-section";
 import { ProductSection } from "../components/product-section";
+import {
+  VariantsSection,
+  type VariantState,
+} from "../components/variants-section";
 
 export function CommerceProductDetailsPage() {
   const {
@@ -30,6 +34,11 @@ export function CommerceProductDetailsPage() {
     onMediaChange,
     formErrors,
     t,
+    defaultCurrency,
+    onVariantChange,
+    onVariantPriceChange,
+    onAddVariant,
+    onRemoveVariant,
   } = useProductDetails();
   const [jsonView, setJsonView] = useState(false);
 
@@ -69,7 +78,14 @@ export function CommerceProductDetailsPage() {
               onMediaChange={onMediaChange}
             />
 
-            {/* Varaint Product */}
+            <VariantsSection
+              variants={(data.variants ?? []) as VariantState[]}
+              defaultCurrency={defaultCurrency}
+              onAddVariant={onAddVariant}
+              onRemoveVariant={onRemoveVariant}
+              onVariantChange={onVariantChange}
+              onVariantPriceChange={onVariantPriceChange}
+            />
 
             {/* SEO Section */}
             <SeoSection

--- a/packages/plugin-commerce-dashboard/src/modules/products/pages/product-details.tsx
+++ b/packages/plugin-commerce-dashboard/src/modules/products/pages/product-details.tsx
@@ -37,8 +37,11 @@ export function CommerceProductDetailsPage() {
     defaultCurrency,
     onVariantChange,
     onVariantPriceChange,
+    onVariantGalleryChange,
     onAddVariant,
     onRemoveVariant,
+    variantErrors,
+    variantGalleryOptions,
   } = useProductDetails();
   const [jsonView, setJsonView] = useState(false);
 
@@ -81,10 +84,13 @@ export function CommerceProductDetailsPage() {
             <VariantsSection
               variants={(data.variants ?? []) as VariantState[]}
               defaultCurrency={defaultCurrency}
+              productGallery={variantGalleryOptions}
+              variantErrors={variantErrors}
               onAddVariant={onAddVariant}
               onRemoveVariant={onRemoveVariant}
               onVariantChange={onVariantChange}
               onVariantPriceChange={onVariantPriceChange}
+              onVariantGalleryChange={onVariantGalleryChange}
             />
 
             {/* SEO Section */}

--- a/packages/plugin-commerce-dashboard/src/modules/products/pages/product-details.tsx
+++ b/packages/plugin-commerce-dashboard/src/modules/products/pages/product-details.tsx
@@ -10,6 +10,7 @@ import { SeoSection } from "../components/seo-section";
 import { UnsavedChangesDialog } from "../../collections/components/unsaved-changes-dialog";
 import { SettingsSection } from "../components/settings-section";
 import { ProductSection } from "../components/product-section";
+import { OptionsSection } from "../components/options-section";
 import {
   VariantsSection,
   type VariantState,
@@ -42,6 +43,12 @@ export function CommerceProductDetailsPage() {
     onRemoveVariant,
     variantErrors,
     variantGalleryOptions,
+    productOptions,
+    onAddOption,
+    onRemoveOption,
+    onOptionChange,
+    onOptionValueAdd,
+    onOptionValueRemove,
   } = useProductDetails();
   const [jsonView, setJsonView] = useState(false);
 
@@ -81,10 +88,20 @@ export function CommerceProductDetailsPage() {
               onMediaChange={onMediaChange}
             />
 
+            <OptionsSection
+              options={productOptions}
+              onAddOption={onAddOption}
+              onRemoveOption={onRemoveOption}
+              onOptionChange={onOptionChange}
+              onOptionValueAdd={onOptionValueAdd}
+              onOptionValueRemove={onOptionValueRemove}
+            />
+
             <VariantsSection
               variants={(data.variants ?? []) as VariantState[]}
               defaultCurrency={defaultCurrency}
               productGallery={variantGalleryOptions}
+              productOptions={productOptions}
               variantErrors={variantErrors}
               onAddVariant={onAddVariant}
               onRemoveVariant={onRemoveVariant}


### PR DESCRIPTION
## Summary
- add a dedicated variants section to the commerce product details page with inline forms and backorder toggles
- extend the product details hook to manage variant state, default currency, and persist variants on save
- localize the new variant controls in both English and Italian

## Testing
- pnpm --filter @kitejs-cms/plugin-commerce-dashboard lint *(fails: corepack cannot download pnpm because the proxy blocks the request)*

------
https://chatgpt.com/codex/tasks/task_e_6904cfb16f788328a306a2b712951689